### PR TITLE
Feature/6

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 
 A ProvWasm smart contract that provides on-chain services to the ATS Exchange.
 
-### Nomenclature
+### Glossary
 
 The following terms are used to identify parts of a token exchange. It is strongly influenced by Forex:
 - token pair - two different currencies that are traded in exchange for each other (ex: BTC/HASH)

--- a/schema/ask_order.json
+++ b/schema/ask_order.json
@@ -7,7 +7,9 @@
     "class",
     "id",
     "owner",
-    "quote"
+    "price",
+    "quote",
+    "size"
   ],
   "properties": {
     "base": {
@@ -22,8 +24,14 @@
     "owner": {
       "$ref": "#/definitions/HumanAddr"
     },
+    "price": {
+      "$ref": "#/definitions/Decimal"
+    },
     "quote": {
-      "$ref": "#/definitions/Coin"
+      "type": "string"
+    },
+    "size": {
+      "$ref": "#/definitions/Uint128"
     }
   },
   "definitions": {
@@ -77,6 +85,10 @@
           "type": "string"
         }
       }
+    },
+    "Decimal": {
+      "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0\n\nThe greatest possible value that can be represented is 340282366920938463463.374607431768211455 (which is (2^128 - 1) / 10^18)",
+      "type": "string"
     },
     "HumanAddr": {
       "type": "string"

--- a/schema/ask_order.json
+++ b/schema/ask_order.json
@@ -25,7 +25,7 @@
       "$ref": "#/definitions/HumanAddr"
     },
     "price": {
-      "$ref": "#/definitions/Decimal"
+      "$ref": "#/definitions/Uint128"
     },
     "quote": {
       "type": "string"
@@ -85,10 +85,6 @@
           "type": "string"
         }
       }
-    },
-    "Decimal": {
-      "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0\n\nThe greatest possible value that can be represented is 340282366920938463463.374607431768211455 (which is (2^128 - 1) / 10^18)",
-      "type": "string"
     },
     "HumanAddr": {
       "type": "string"

--- a/schema/bid_order.json
+++ b/schema/bid_order.json
@@ -6,11 +6,13 @@
     "base",
     "id",
     "owner",
-    "quote"
+    "price",
+    "quote",
+    "size"
   ],
   "properties": {
     "base": {
-      "$ref": "#/definitions/Coin"
+      "type": "string"
     },
     "id": {
       "type": "string"
@@ -18,8 +20,14 @@
     "owner": {
       "$ref": "#/definitions/HumanAddr"
     },
+    "price": {
+      "$ref": "#/definitions/Decimal"
+    },
     "quote": {
       "$ref": "#/definitions/Coin"
+    },
+    "size": {
+      "$ref": "#/definitions/Uint128"
     }
   },
   "definitions": {
@@ -37,6 +45,10 @@
           "type": "string"
         }
       }
+    },
+    "Decimal": {
+      "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0\n\nThe greatest possible value that can be represented is 340282366920938463463.374607431768211455 (which is (2^128 - 1) / 10^18)",
+      "type": "string"
     },
     "HumanAddr": {
       "type": "string"

--- a/schema/bid_order.json
+++ b/schema/bid_order.json
@@ -21,7 +21,7 @@
       "$ref": "#/definitions/HumanAddr"
     },
     "price": {
-      "$ref": "#/definitions/Decimal"
+      "$ref": "#/definitions/Uint128"
     },
     "quote": {
       "$ref": "#/definitions/Coin"
@@ -45,10 +45,6 @@
           "type": "string"
         }
       }
-    },
-    "Decimal": {
-      "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0\n\nThe greatest possible value that can be represented is 340282366920938463463.374607431768211455 (which is (2^128 - 1) / 10^18)",
-      "type": "string"
     },
     "HumanAddr": {
       "type": "string"

--- a/schema/execute_msg.json
+++ b/schema/execute_msg.json
@@ -50,14 +50,18 @@
           "type": "object",
           "required": [
             "id",
+            "price",
             "quote"
           ],
           "properties": {
             "id": {
               "type": "string"
             },
+            "price": {
+              "$ref": "#/definitions/Decimal"
+            },
             "quote": {
-              "$ref": "#/definitions/Coin"
+              "type": "string"
             }
           }
         }
@@ -73,14 +77,22 @@
           "type": "object",
           "required": [
             "base",
-            "id"
+            "id",
+            "price",
+            "size"
           ],
           "properties": {
             "base": {
-              "$ref": "#/definitions/Coin"
+              "type": "string"
             },
             "id": {
               "type": "string"
+            },
+            "price": {
+              "$ref": "#/definitions/Decimal"
+            },
+            "size": {
+              "$ref": "#/definitions/Uint128"
             }
           }
         }
@@ -187,20 +199,9 @@
     }
   ],
   "definitions": {
-    "Coin": {
-      "type": "object",
-      "required": [
-        "amount",
-        "denom"
-      ],
-      "properties": {
-        "amount": {
-          "$ref": "#/definitions/Uint128"
-        },
-        "denom": {
-          "type": "string"
-        }
-      }
+    "Decimal": {
+      "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0\n\nThe greatest possible value that can be represented is 340282366920938463463.374607431768211455 (which is (2^128 - 1) / 10^18)",
+      "type": "string"
     },
     "Uint128": {
       "type": "string"

--- a/schema/execute_msg.json
+++ b/schema/execute_msg.json
@@ -58,7 +58,7 @@
               "type": "string"
             },
             "price": {
-              "$ref": "#/definitions/Decimal"
+              "$ref": "#/definitions/Uint128"
             },
             "quote": {
               "type": "string"
@@ -89,7 +89,7 @@
               "type": "string"
             },
             "price": {
-              "$ref": "#/definitions/Decimal"
+              "$ref": "#/definitions/Uint128"
             },
             "size": {
               "$ref": "#/definitions/Uint128"
@@ -199,10 +199,6 @@
     }
   ],
   "definitions": {
-    "Decimal": {
-      "description": "A fixed-point decimal value with 18 fractional digits, i.e. Decimal(1_000_000_000_000_000_000) == 1.0\n\nThe greatest possible value that can be represented is 340282366920938463463.374607431768211455 (which is (2^128 - 1) / 10^18)",
-      "type": "string"
-    },
     "Uint128": {
       "type": "string"
     }

--- a/src/error.rs
+++ b/src/error.rs
@@ -3,8 +3,8 @@ use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum ContractError {
-    #[error("Ask Order does not match Bid Order")]
-    AskBidMismatch,
+    #[error("Ask Order price does not match Bid Order price")]
+    AskBidPriceMismatch,
 
     #[error("Ask Order not ready: {current_status:?}")]
     AskOrderNotReady { current_status: String },

--- a/src/error.rs
+++ b/src/error.rs
@@ -33,6 +33,9 @@ pub enum ContractError {
     #[error("One quote required in order")]
     QuoteQuantity,
 
+    #[error("Sent funds does not match order")]
+    SentFundsOrderMismatch,
+
     #[error("{0}")]
     Std(#[from] StdError),
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+extern crate cosmwasm_std;
+
 pub mod contract;
 pub mod contract_info;
 pub mod error;

--- a/src/msg.rs
+++ b/src/msg.rs
@@ -1,5 +1,5 @@
 use crate::error::ContractError;
-use cosmwasm_std::{Decimal, HumanAddr, Uint128};
+use cosmwasm_std::{HumanAddr, Uint128};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -68,12 +68,12 @@ pub enum ExecuteMsg {
     CreateAsk {
         id: String,
         quote: String,
-        price: Decimal,
+        price: Uint128,
     },
     CreateBid {
         id: String,
         base: String,
-        price: Decimal,
+        price: Uint128,
         size: Uint128,
     },
     ApproveAsk {

--- a/src/msg.rs
+++ b/src/msg.rs
@@ -1,5 +1,5 @@
 use crate::error::ContractError;
-use cosmwasm_std::{Coin, HumanAddr, Uint128};
+use cosmwasm_std::{Decimal, HumanAddr, Uint128};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
@@ -59,15 +59,39 @@ impl Validate for InstantiateMsg {
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum ExecuteMsg {
-    CancelAsk { id: String },
-    CancelBid { id: String },
-    CreateAsk { id: String, quote: Coin },
-    CreateBid { id: String, base: Coin },
-    ApproveAsk { id: String },
-    RejectAsk { id: String },
-    ExpireAsk { id: String },
-    ExpireBid { id: String },
-    ExecuteMatch { ask_id: String, bid_id: String },
+    CancelAsk {
+        id: String,
+    },
+    CancelBid {
+        id: String,
+    },
+    CreateAsk {
+        id: String,
+        quote: String,
+        price: Decimal,
+    },
+    CreateBid {
+        id: String,
+        base: String,
+        price: Decimal,
+        size: Uint128,
+    },
+    ApproveAsk {
+        id: String,
+    },
+    RejectAsk {
+        id: String,
+    },
+    ExpireAsk {
+        id: String,
+    },
+    ExpireBid {
+        id: String,
+    },
+    ExecuteMatch {
+        ask_id: String,
+        bid_id: String,
+    },
 }
 
 impl Validate for ExecuteMsg {
@@ -87,26 +111,34 @@ impl Validate for ExecuteMsg {
         let mut invalid_fields: Vec<&str> = vec![];
 
         match self {
-            ExecuteMsg::CreateAsk { id, quote } => {
+            ExecuteMsg::CreateAsk { id, quote, price } => {
                 if id.is_empty() {
                     invalid_fields.push("id");
                 }
-                if quote.amount.eq(&Uint128::zero()) {
-                    invalid_fields.push("quote.amount");
+                if price.is_zero() {
+                    invalid_fields.push("price");
                 }
-                if quote.denom.is_empty() {
-                    invalid_fields.push("quote.denom");
+                if quote.is_empty() {
+                    invalid_fields.push("quote");
                 }
             }
-            ExecuteMsg::CreateBid { id, base } => {
+            ExecuteMsg::CreateBid {
+                id,
+                base,
+                price,
+                size,
+            } => {
                 if id.is_empty() {
                     invalid_fields.push("id");
                 }
-                if base.amount.eq(&Uint128::zero()) {
-                    invalid_fields.push("base.amount");
+                if base.is_empty() {
+                    invalid_fields.push("base");
                 }
-                if base.denom.is_empty() {
-                    invalid_fields.push("base.denom");
+                if price.is_zero() {
+                    invalid_fields.push("price");
+                }
+                if size.is_zero() {
+                    invalid_fields.push("size");
                 }
             }
             ExecuteMsg::CancelAsk { id } => {

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,4 +1,4 @@
-use cosmwasm_std::{Coin, Decimal, HumanAddr, Storage, Uint128};
+use cosmwasm_std::{Coin, HumanAddr, Storage, Uint128};
 use cosmwasm_storage::{bucket, bucket_read, Bucket, ReadonlyBucket};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -24,7 +24,7 @@ pub struct AskOrder {
     pub class: AskOrderClass,
     pub id: String,
     pub owner: HumanAddr,
-    pub price: Decimal,
+    pub price: Uint128,
     pub quote: String,
     pub size: Uint128,
 }
@@ -34,7 +34,7 @@ pub struct BidOrder {
     pub base: String,
     pub id: String,
     pub owner: HumanAddr,
-    pub price: Decimal,
+    pub price: Uint128,
     pub quote: Coin,
     pub size: Uint128,
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,4 +1,4 @@
-use cosmwasm_std::{Coin, HumanAddr, Storage};
+use cosmwasm_std::{Coin, Decimal, HumanAddr, Storage, Uint128};
 use cosmwasm_storage::{bucket, bucket_read, Bucket, ReadonlyBucket};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -21,18 +21,22 @@ pub enum AskOrderClass {
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct AskOrder {
     pub base: Coin,
+    pub class: AskOrderClass,
     pub id: String,
     pub owner: HumanAddr,
-    pub quote: Coin,
-    pub class: AskOrderClass,
+    pub price: Decimal,
+    pub quote: String,
+    pub size: Uint128,
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 pub struct BidOrder {
-    pub base: Coin,
+    pub base: String,
     pub id: String,
     pub owner: HumanAddr,
+    pub price: Decimal,
     pub quote: Coin,
+    pub size: Uint128,
 }
 
 pub fn get_ask_storage(storage: &mut dyn Storage) -> Bucket<AskOrder> {


### PR DESCRIPTION
### Partial Orders design

- Ask and Bid orders now have fields `price` and `size`.  See [ask_order](https://github.com/provenance-io/ats-smart-contract/blob/cf9be456692c282b825fc1daa98a6ecc64931e96/schema/ask_order.json#L27-L35) and  [bid_order](https://github.com/provenance-io/ats-smart-contract/blob/cf9be456692c282b825fc1daa98a6ecc64931e96/schema/bid_order.json#L23-L31)
  - `price` = integer price of 1 base, always in terms of quote/base. eg: an ask order asking 2 usd for 1 gme would have a price of 2; a bid order bidding 2 usd for 1 gme would have a price of 2.
  - `size` = the amount of base to sell or buy
- when creating an Ask order, the size **IS NOT** specified as it is derived from the sent assets. see [create_ask](https://github.com/provenance-io/ats-smart-contract/blob/cf9be456692c282b825fc1daa98a6ecc64931e96/schema/execute_msg.json#L43-L69)
- when creating a Bid order, the size **IS** specified. see [create_bid](https://github.com/provenance-io/ats-smart-contract/blob/cf9be456692c282b825fc1daa98a6ecc64931e96/schema/execute_msg.json#L70-L100)
- Prices must match for the execution to take place, otherwise a mismatch error is returned.
- The side of the match with minimum size will always fully fil and be removed from storage, leaving the other side of the match partially filled with the remaining order still active.
- If both sides of the match are the same size, both will fully fill and be removed from storage

closes #6 