### PR TITLE
allow matching orders with price differences when order prices overlap

### DIFF
--- a/schema/execute_msg.json
+++ b/schema/execute_msg.json
@@ -184,7 +184,8 @@
           "type": "object",
           "required": [
             "ask_id",
-            "bid_id"
+            "bid_id",
+            "price"
           ],
           "properties": {
             "ask_id": {
@@ -192,6 +193,9 @@
             },
             "bid_id": {
               "type": "string"
+            },
+            "price": {
+              "$ref": "#/definitions/Uint128"
             }
           }
         }

--- a/src/msg.rs
+++ b/src/msg.rs
@@ -91,6 +91,7 @@ pub enum ExecuteMsg {
     ExecuteMatch {
         ask_id: String,
         bid_id: String,
+        price: Uint128,
     },
 }
 
@@ -115,7 +116,7 @@ impl Validate for ExecuteMsg {
                 if id.is_empty() {
                     invalid_fields.push("id");
                 }
-                if price.is_zero() {
+                if price.le(&Uint128(0)) {
                     invalid_fields.push("price");
                 }
                 if quote.is_empty() {
@@ -134,7 +135,7 @@ impl Validate for ExecuteMsg {
                 if base.is_empty() {
                     invalid_fields.push("base");
                 }
-                if price.is_zero() {
+                if price.le(&Uint128(0)) {
                     invalid_fields.push("price");
                 }
                 if size.is_zero() {
@@ -151,12 +152,19 @@ impl Validate for ExecuteMsg {
                     invalid_fields.push("id");
                 }
             }
-            ExecuteMsg::ExecuteMatch { ask_id, bid_id } => {
+            ExecuteMsg::ExecuteMatch {
+                ask_id,
+                bid_id,
+                price,
+            } => {
                 if ask_id.is_empty() {
                     invalid_fields.push("ask_id");
                 }
                 if bid_id.is_empty() {
                     invalid_fields.push("bid_id");
+                }
+                if price.le(&Uint128(0)) {
+                    invalid_fields.push("price");
                 }
             }
             ExecuteMsg::ApproveAsk { id } => {


### PR DESCRIPTION
ExecuteMatch message now has a `price` parameter which indicates which order price to execute at, the Ask or Bid price.

- if Ask price is lower than Bid price, use ExecuteMatch.price
  - if ExecuteMatch.price is the Ask price, calculate total and process. issue refund to bidder if the bid order is completed (size=0)
  - if ExecuteMatch.price is the Bid price, calculate total and process. no refund is expected since bidder sent correct amount
  - if ExecuteMatch.price is neither the Ask nor Bid price, return error

closes #15 