### PR TITLE
change bidder refund to separate message

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4,7 +4,7 @@ version = 3
 
 [[package]]
 name = "ats-smart-contract"
-version = "0.14.0-beta1.1"
+version = "0.14.0-beta1.2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ats-smart-contract"
-version = "0.14.0-beta1.1"
+version = "0.14.0-beta1.2"
 authors = ["Ken Talley <ktalley@figure.com>"]
 edition = "2018"
 


### PR DESCRIPTION
this moves the bidder refund denom to its own message instead of combined with the purchase base denom message

closes #20 