### PR TITLE
add restricted marker support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
 name = "ats-smart-contract"
-version = "0.14.5"
+version = "0.15.0"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",
@@ -20,6 +20,7 @@ dependencies = [
  "provwasm-std",
  "rust_decimal",
  "schemars",
+ "semver",
  "serde",
  "serde_json",
  "thiserror",
@@ -78,9 +79,9 @@ checksum = "9f6b64db6932c7e49332728e3a6bd82c6b7e16016607d20923b537c3bc4c0d5f"
 
 [[package]]
 name = "cosmwasm-crypto"
-version = "0.14.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ddbf475b0e8a9bd813607d59144ad3f71d90dd66c5e975a46ac2b72ce754121"
+checksum = "038089cdadfe61e4e85617d91cecec2c49f828db8e5986bb85e29d0b29c59b77"
 dependencies = [
  "digest",
  "ed25519-zebra",
@@ -91,9 +92,9 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-derive"
-version = "0.14.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4e62de21147741486c6d4adc28850b102dcad1888d9fc2d0a200ca423284563"
+checksum = "628bf3da935843795a7f52678262ef06398878b0cf4c89b69612d8525ea27b84"
 dependencies = [
  "syn",
 ]
@@ -110,9 +111,9 @@ dependencies = [
 
 [[package]]
 name = "cosmwasm-std"
-version = "0.14.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db14129579ddb1dbd8a28376673d61090f35c9069978eb875d489c275bb76315"
+checksum = "22de097cf4f7e7f575f51a22de7260932756ccfe499e005f98244a3043470e48"
 dependencies = [
  "base64",
  "cosmwasm-crypto",
@@ -121,13 +122,14 @@ dependencies = [
  "serde",
  "serde-json-wasm",
  "thiserror",
+ "uint",
 ]
 
 [[package]]
 name = "cosmwasm-storage"
-version = "0.14.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "13b03dc324ef7b5bce224e096d67bc67e12aadc8fbacb7c8c796eac40cf7c4b8"
+checksum = "f4abf200c2651e123595b18edf67df8702d19127b487d8b3e115dcc6c2ac0e0e"
 dependencies = [
  "cosmwasm-std",
  "serde",
@@ -141,6 +143,12 @@ checksum = "ed00c67cb5d0a7d64a44f6ad2668db7e7530311dd53ea79bcd4fb022c64911c8"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "crunchy"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-mac"
@@ -379,9 +387,9 @@ dependencies = [
 
 [[package]]
 name = "provwasm-std"
-version = "0.14.0"
+version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93db7cee9e38618867b30f0418ac1e82f6c7cce0773a27470aa75a3a63b6cd0d"
+checksum = "1e63c047c77ec4ec7d193c75679452c3b85440c0257986e5243dc2e3ab32de5a"
 dependencies = [
  "cosmwasm-std",
  "schemars",
@@ -452,6 +460,12 @@ dependencies = [
  "serde_derive_internals",
  "syn",
 ]
+
+[[package]]
+name = "semver"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f3aac57ee7f3272d8395c6e4f502f434f0e289fcd62876f70daa008c20dcabe"
 
 [[package]]
 name = "serde"
@@ -528,6 +542,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "subtle"
 version = "2.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -569,6 +589,18 @@ name = "typenum"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879f6906492a7cd215bfa4cf595b600146ccfac0c79bcbd1f3000162af5e8b06"
+
+[[package]]
+name = "uint"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e11fe9a9348741cf134085ad57c249508345fe16411b3d7fb4ff2da2f1d6382e"
+dependencies = [
+ "byteorder",
+ "crunchy",
+ "hex",
+ "static_assertions",
+]
 
 [[package]]
 name = "unicode-xid"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ats-smart-contract"
-version = "0.14.5"
+version = "0.15.0"
 authors = ["Ken Talley <ktalley@figure.com>"]
 edition = "2018"
 
@@ -28,12 +28,13 @@ overflow-checks = true
 #backtraces = ["cosmwasm-std/backtraces"]
 
 [dependencies]
-cosmwasm-std = { version = "0.14.0", features = ["staking"] }
-cosmwasm-storage = { version = "0.14.0" }
+cosmwasm-std = { version = "0.14.1" }
+cosmwasm-storage = { version = "0.14.1" }
 cw-storage-plus = { version = "0.6.0" }
-provwasm-std = { version = "0.14.0" }
+provwasm-std = { version = "0.14.1" }
 rust_decimal = { version = "1.12.2" }
 schemars = "0.8.1"
+semver = "1.0.3"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }
 serde_json = "1.0.64"
 thiserror = { version = "1.0.23" }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,7 +29,7 @@ overflow-checks = true
 
 [dependencies]
 cosmwasm-std = { version = "0.14.1" }
-cosmwasm-storage = { version = "0.14.1" }
+cosmwasm-storage = { version = "0.14.1", features = ["iterator"] }
 cw-storage-plus = { version = "0.6.0" }
 provwasm-std = { version = "0.14.1" }
 rust_decimal = { version = "1.12.2" }

--- a/examples/schema.rs
+++ b/examples/schema.rs
@@ -3,9 +3,10 @@ use std::fs::create_dir_all;
 
 use cosmwasm_schema::{export_schema, remove_schemas, schema_for};
 
-use ats_smart_contract::contract_info::ContractInfo;
+use ats_smart_contract::contract_info::ContractInfoV1;
 use ats_smart_contract::msg::{ExecuteMsg, InstantiateMsg, QueryMsg};
 use ats_smart_contract::state::{AskOrder, AskOrderClass, AskOrderStatus, BidOrder};
+use ats_smart_contract::version_info::VersionInfoV1;
 
 fn main() {
     let mut out_dir = current_dir().unwrap();
@@ -17,7 +18,8 @@ fn main() {
     export_schema(&schema_for!(AskOrderClass), &out_dir);
     export_schema(&schema_for!(AskOrderStatus), &out_dir);
     export_schema(&schema_for!(BidOrder), &out_dir);
-    export_schema(&schema_for!(ContractInfo), &out_dir);
+    export_schema(&schema_for!(ContractInfoV1), &out_dir);
+    export_schema(&schema_for!(VersionInfoV1), &out_dir);
     export_schema(&schema_for!(ExecuteMsg), &out_dir);
     export_schema(&schema_for!(InstantiateMsg), &out_dir);
     export_schema(&schema_for!(QueryMsg), &out_dir);

--- a/examples/schema.rs
+++ b/examples/schema.rs
@@ -3,9 +3,10 @@ use std::fs::create_dir_all;
 
 use cosmwasm_schema::{export_schema, remove_schemas, schema_for};
 
+use ats_smart_contract::ask_order::{AskOrder, AskOrderClass, AskOrderStatus};
+use ats_smart_contract::bid_order::BidOrder;
 use ats_smart_contract::contract_info::ContractInfoV1;
 use ats_smart_contract::msg::{ExecuteMsg, InstantiateMsg, QueryMsg};
-use ats_smart_contract::state::{AskOrder, AskOrderClass, AskOrderStatus, BidOrder};
 use ats_smart_contract::version_info::VersionInfoV1;
 
 fn main() {

--- a/schema/ask_order.json
+++ b/schema/ask_order.json
@@ -1,6 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "AskOrder",
+  "deprecated": true,
   "type": "object",
   "required": [
     "base",

--- a/schema/bid_order.json
+++ b/schema/bid_order.json
@@ -1,6 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "BidOrder",
+  "deprecated": true,
   "type": "object",
   "required": [
     "base",

--- a/schema/contract_info_v1.json
+++ b/schema/contract_info_v1.json
@@ -1,25 +1,22 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "title": "ContractInfo",
+  "title": "ContractInfoV1",
   "type": "object",
   "required": [
+    "approvers",
     "ask_required_attributes",
     "base_denom",
     "bid_required_attributes",
     "bind_name",
     "convertible_base_denoms",
-    "definition",
     "executors",
-    "issuers",
     "name",
     "price_precision",
     "size_increment",
-    "supported_quote_denoms",
-    "version"
+    "supported_quote_denoms"
   ],
   "properties": {
     "approvers": {
-      "default": [],
       "type": "array",
       "items": {
         "$ref": "#/definitions/Addr"
@@ -49,17 +46,7 @@
         "type": "string"
       }
     },
-    "definition": {
-      "type": "string"
-    },
     "executors": {
-      "type": "array",
-      "items": {
-        "$ref": "#/definitions/Addr"
-      }
-    },
-    "issuers": {
-      "deprecated": true,
       "type": "array",
       "items": {
         "$ref": "#/definitions/Addr"
@@ -79,9 +66,6 @@
       "items": {
         "type": "string"
       }
-    },
-    "version": {
-      "type": "string"
     }
   },
   "definitions": {

--- a/schema/execute_msg.json
+++ b/schema/execute_msg.json
@@ -118,6 +118,8 @@
             "base",
             "id",
             "price",
+            "quote",
+            "quote_size",
             "size"
           ],
           "properties": {
@@ -129,6 +131,12 @@
             },
             "price": {
               "type": "string"
+            },
+            "quote": {
+              "type": "string"
+            },
+            "quote_size": {
+              "$ref": "#/definitions/Uint128"
             },
             "size": {
               "$ref": "#/definitions/Uint128"

--- a/schema/execute_msg.json
+++ b/schema/execute_msg.json
@@ -71,11 +71,16 @@
         "create_ask": {
           "type": "object",
           "required": [
+            "base",
             "id",
             "price",
-            "quote"
+            "quote",
+            "size"
           ],
           "properties": {
+            "base": {
+              "type": "string"
+            },
             "id": {
               "type": "string"
             },
@@ -84,6 +89,9 @@
             },
             "quote": {
               "type": "string"
+            },
+            "size": {
+              "$ref": "#/definitions/Uint128"
             }
           }
         }

--- a/schema/execute_msg.json
+++ b/schema/execute_msg.json
@@ -11,11 +11,19 @@
         "approve_ask": {
           "type": "object",
           "required": [
-            "id"
+            "base",
+            "id",
+            "size"
           ],
           "properties": {
+            "base": {
+              "type": "string"
+            },
             "id": {
               "type": "string"
+            },
+            "size": {
+              "$ref": "#/definitions/Uint128"
             }
           }
         }

--- a/schema/instantiate_msg.json
+++ b/schema/instantiate_msg.json
@@ -10,7 +10,6 @@
     "bind_name",
     "convertible_base_denoms",
     "executors",
-    "issuers",
     "name",
     "price_precision",
     "size_increment",
@@ -48,12 +47,6 @@
       }
     },
     "executors": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
-    },
-    "issuers": {
       "type": "array",
       "items": {
         "type": "string"

--- a/schema/query_msg.json
+++ b/schema/query_msg.json
@@ -53,6 +53,18 @@
         }
       },
       "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "get_version_info"
+      ],
+      "properties": {
+        "get_version_info": {
+          "type": "object"
+        }
+      },
+      "additionalProperties": false
     }
   ]
 }

--- a/schema/version_info_v1.json
+++ b/schema/version_info_v1.json
@@ -1,0 +1,17 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "VersionInfoV1",
+  "type": "object",
+  "required": [
+    "definition",
+    "version"
+  ],
+  "properties": {
+    "definition": {
+      "type": "string"
+    },
+    "version": {
+      "type": "string"
+    }
+  }
+}

--- a/src/ask_order.rs
+++ b/src/ask_order.rs
@@ -111,6 +111,7 @@ pub fn get_ask_storage_read(storage: &dyn Storage) -> ReadonlyBucket<AskOrderV1>
 
 #[cfg(test)]
 mod tests {
+    #[allow(deprecated)]
     use crate::ask_order::{
         get_ask_storage_read, migrate_ask_orders, AskOrder, AskOrderClass, AskOrderV1,
         NAMESPACE_ORDER_ASK,

--- a/src/ask_order.rs
+++ b/src/ask_order.rs
@@ -66,7 +66,7 @@ impl From<AskOrder> for AskOrderV1 {
 pub fn migrate_ask_orders(
     store: &mut dyn Storage,
     _api: &dyn Api,
-    _msg: MigrateMsg,
+    _msg: &MigrateMsg,
 ) -> Result<(), ContractError> {
     let version_info = get_version_info(store)?;
     let current_version = Version::parse(&version_info.version)?;
@@ -167,7 +167,7 @@ mod tests {
         migrate_ask_orders(
             &mut deps.storage,
             &deps.api,
-            MigrateMsg { approvers: vec![] },
+            &MigrateMsg { approvers: vec![] },
         )?;
 
         let ask_storage = get_ask_storage_read(&deps.storage);

--- a/src/bid_order.rs
+++ b/src/bid_order.rs
@@ -1,11 +1,16 @@
-use cosmwasm_std::{Addr, Coin, Storage, Uint128};
+use crate::error::ContractError;
+use crate::msg::MigrateMsg;
+use crate::version_info::get_version_info;
+use cosmwasm_std::{Addr, Api, Coin, Order, Storage, Uint128};
 use cosmwasm_storage::{bucket, bucket_read, Bucket, ReadonlyBucket};
 use schemars::JsonSchema;
+use semver::{Version, VersionReq};
 use serde::{Deserialize, Serialize};
 
 pub static NAMESPACE_ORDER_BID: &[u8] = b"bid";
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[deprecated(since = "0.15.0")]
 pub struct BidOrder {
     pub base: String,
     pub id: String,
@@ -14,11 +19,154 @@ pub struct BidOrder {
     pub quote: Coin,
     pub size: Uint128,
 }
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct BidOrderV1 {
+    pub base: String,
+    pub id: String,
+    pub owner: Addr,
+    pub price: String,
+    pub quote: String,
+    pub quote_size: Uint128,
+    pub size: Uint128,
+}
 
-pub fn get_bid_storage(storage: &mut dyn Storage) -> Bucket<BidOrder> {
+#[allow(deprecated)]
+impl From<BidOrder> for BidOrderV1 {
+    fn from(bid_order: BidOrder) -> Self {
+        BidOrderV1 {
+            id: bid_order.id,
+            owner: bid_order.owner,
+            base: bid_order.base,
+            quote: bid_order.quote.denom,
+            quote_size: bid_order.quote.amount,
+            price: bid_order.price,
+            size: bid_order.size,
+        }
+    }
+}
+
+#[allow(deprecated)]
+pub fn migrate_bid_orders(
+    store: &mut dyn Storage,
+    _api: &dyn Api,
+    _msg: &MigrateMsg,
+) -> Result<(), ContractError> {
+    let version_info = get_version_info(store)?;
+    let current_version = Version::parse(&version_info.version)?;
+
+    // version support added in 0.15.0, all previous versions migrate to v1 of state data
+    let upgrade_req = VersionReq::parse("<0.15.0")?;
+
+    if upgrade_req.matches(&current_version) {
+        let legacy_bid_storage: Bucket<BidOrder> = bucket(store, NAMESPACE_ORDER_BID);
+
+        let migrated_bid_orders: Vec<Result<(Vec<u8>, BidOrderV1), ContractError>> =
+            legacy_bid_storage
+                .range(None, None, Order::Ascending)
+                .map(|kv_bid| -> Result<(Vec<u8>, BidOrderV1), ContractError> {
+                    let (bid_key, bid) = kv_bid?;
+                    Ok((bid_key, bid.into()))
+                })
+                .collect();
+
+        let mut bid_storage = get_bid_storage(store);
+        for migrated_bid_order in migrated_bid_orders {
+            let (bid_key, bid) = migrated_bid_order?;
+            bid_storage.save(&bid_key, &bid)?
+        }
+    }
+
+    Ok(())
+}
+
+#[allow(deprecated)]
+pub fn get_legacy_bid_storage(storage: &mut dyn Storage) -> Bucket<BidOrder> {
     bucket(storage, NAMESPACE_ORDER_BID)
 }
 
-pub fn get_bid_storage_read(storage: &dyn Storage) -> ReadonlyBucket<BidOrder> {
+pub fn get_bid_storage(storage: &mut dyn Storage) -> Bucket<BidOrderV1> {
+    bucket(storage, NAMESPACE_ORDER_BID)
+}
+
+pub fn get_bid_storage_read(storage: &dyn Storage) -> ReadonlyBucket<BidOrderV1> {
     bucket_read(storage, NAMESPACE_ORDER_BID)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::bid_order::{
+        get_bid_storage_read, migrate_bid_orders, BidOrderV1, NAMESPACE_ORDER_BID,
+    };
+    use crate::contract_info::set_legacy_contract_info;
+    use crate::error::ContractError;
+    use crate::msg::MigrateMsg;
+    use crate::{bid_order, contract_info};
+    use cosmwasm_std::{coin, Addr, Uint128};
+    use cosmwasm_storage::{bucket, Bucket};
+    use provwasm_mocks::mock_dependencies;
+
+    #[test]
+    #[allow(deprecated)]
+    pub fn migrate_legacy_bid_to_v1() -> Result<(), ContractError> {
+        let mut deps = mock_dependencies(&[]);
+
+        set_legacy_contract_info(
+            &mut deps.storage,
+            &contract_info::ContractInfo {
+                name: "contract_name".to_string(),
+                definition: "contract_def".to_string(),
+                version: "0.14.99".to_string(),
+                bind_name: "bind_name".to_string(),
+                base_denom: "base_1".to_string(),
+                convertible_base_denoms: vec![],
+                supported_quote_denoms: vec![],
+                approvers: vec![],
+                executors: vec![],
+                issuers: vec![],
+                ask_required_attributes: vec![],
+                bid_required_attributes: vec![],
+                price_precision: Uint128(2),
+                size_increment: Uint128(100),
+            },
+        )?;
+
+        let mut legacy_bid_storage: Bucket<bid_order::BidOrder> =
+            bucket(&mut deps.storage, NAMESPACE_ORDER_BID);
+
+        legacy_bid_storage.save(
+            b"id",
+            &bid_order::BidOrder {
+                base: "base_1".to_string(),
+                id: "id".to_string(),
+                owner: Addr::unchecked("bidder"),
+                price: "10".to_string(),
+                quote: coin(1000, "quote_1"),
+                size: Uint128(100),
+            },
+        )?;
+
+        migrate_bid_orders(
+            &mut deps.storage,
+            &deps.api,
+            &MigrateMsg { approvers: vec![] },
+        )?;
+
+        let bid_storage = get_bid_storage_read(&deps.storage);
+        let migrated_bid = bid_storage.load(b"id")?;
+
+        assert_eq!(
+            migrated_bid,
+            BidOrderV1 {
+                id: "id".to_string(),
+                owner: Addr::unchecked("bidder"),
+                base: "base_1".to_string(),
+                quote: "quote_1".to_string(),
+                quote_size: Uint128(1000),
+                price: "10".to_string(),
+                size: Uint128(100)
+            }
+        );
+
+        Ok(())
+    }
 }

--- a/src/bid_order.rs
+++ b/src/bid_order.rs
@@ -1,0 +1,24 @@
+use cosmwasm_std::{Addr, Coin, Storage, Uint128};
+use cosmwasm_storage::{bucket, bucket_read, Bucket, ReadonlyBucket};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+pub static NAMESPACE_ORDER_BID: &[u8] = b"bid";
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct BidOrder {
+    pub base: String,
+    pub id: String,
+    pub owner: Addr,
+    pub price: String,
+    pub quote: Coin,
+    pub size: Uint128,
+}
+
+pub fn get_bid_storage(storage: &mut dyn Storage) -> Bucket<BidOrder> {
+    bucket(storage, NAMESPACE_ORDER_BID)
+}
+
+pub fn get_bid_storage_read(storage: &dyn Storage) -> ReadonlyBucket<BidOrder> {
+    bucket_read(storage, NAMESPACE_ORDER_BID)
+}

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -8,7 +8,8 @@ use provwasm_std::{
 };
 
 use crate::ask_order::{
-    get_ask_storage, get_ask_storage_read, AskOrderClass, AskOrderStatus, AskOrderV1,
+    get_ask_storage, get_ask_storage_read, migrate_ask_orders, AskOrderClass, AskOrderStatus,
+    AskOrderV1,
 };
 use crate::bid_order::{get_bid_storage, get_bid_storage_read, BidOrder};
 use crate::contract_info::{
@@ -915,7 +916,10 @@ pub fn migrate(deps: DepsMut, _env: Env, msg: MigrateMsg) -> Result<Response, Co
     msg.validate()?;
 
     // migrate contract_info
-    migrate_contract_info(deps.storage, deps.api, msg)?;
+    migrate_contract_info(deps.storage, deps.api, &msg)?;
+
+    // migrate ask orders
+    migrate_ask_orders(deps.storage, deps.api, &msg)?;
 
     // lastly, migrate version_info
     migrate_version_info(deps.storage)?;

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -7,16 +7,16 @@ use provwasm_std::{
     ProvenanceRoute,
 };
 
+use crate::ask_order::{
+    get_ask_storage, get_ask_storage_read, AskOrderClass, AskOrderStatus, AskOrderV1,
+};
+use crate::bid_order::{get_bid_storage, get_bid_storage_read, BidOrder};
 use crate::contract_info::{
     get_contract_info, migrate_contract_info, set_contract_info, ContractInfoV1,
 };
 use crate::error::ContractError;
 use crate::error::ContractError::InvalidPricePrecisionSizePair;
 use crate::msg::{ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg, Validate};
-use crate::state::{
-    get_ask_storage, get_ask_storage_read, get_bid_storage, get_bid_storage_read, AskOrderClass,
-    AskOrderStatus, AskOrderV1, BidOrder,
-};
 use crate::version_info::{get_version_info, migrate_version_info};
 use rust_decimal::prelude::{FromStr, ToPrimitive, Zero};
 use rust_decimal::Decimal;
@@ -952,7 +952,8 @@ mod tests {
         Marker, MarkerMsgParams, NameMsgParams, ProvenanceMsg, ProvenanceMsgParams, ProvenanceRoute,
     };
 
-    use crate::state::{get_bid_storage_read, AskOrderClass, AskOrderV1};
+    use crate::ask_order::{AskOrderClass, AskOrderV1};
+    use crate::bid_order::get_bid_storage_read;
 
     use super::*;
     use provwasm_mocks::mock_dependencies;

--- a/src/contract_info.rs
+++ b/src/contract_info.rs
@@ -1,14 +1,21 @@
-use cosmwasm_std::{Addr, StdResult, Storage, Uint128};
+use cosmwasm_std::{Addr, Api, Storage, Uint128};
 use cw_storage_plus::Item;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::error::ContractError;
+use crate::msg::MigrateMsg;
+use crate::version_info::{get_version_info, PACKAGE_VERSION};
+use semver::{Version, VersionReq};
 
 const CONTRACT_INFO_NAMESPACE: &str = "contract_info";
-pub const CONTRACT_INFO: Item<ContractInfo> = Item::new(CONTRACT_INFO_NAMESPACE);
 
-#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[allow(deprecated)]
+const CONTRACT_INFO: Item<ContractInfo> = Item::new(CONTRACT_INFO_NAMESPACE);
+const CONTRACT_INFO_V1: Item<ContractInfoV1> = Item::new(CONTRACT_INFO_NAMESPACE);
+
+#[derive(Serialize, Deserialize)]
+#[deprecated(since = "0.15.0")]
 pub struct ContractInfo {
     pub name: String,
     pub definition: String,
@@ -17,10 +24,8 @@ pub struct ContractInfo {
     pub base_denom: String,
     pub convertible_base_denoms: Vec<String>,
     pub supported_quote_denoms: Vec<String>,
-    #[serde(default)]
     pub approvers: Vec<Addr>,
     pub executors: Vec<Addr>,
-    #[deprecated(since = "0.14.2")]
     pub issuers: Vec<Addr>,
     pub ask_required_attributes: Vec<String>,
     pub bid_required_attributes: Vec<String>,
@@ -28,23 +33,103 @@ pub struct ContractInfo {
     pub size_increment: Uint128,
 }
 
-pub fn set_contract_info(
-    store: &mut dyn Storage,
-    contract_info: &ContractInfo,
-) -> Result<(), ContractError> {
-    let result = CONTRACT_INFO.save(store, &contract_info);
-    result.map_err(ContractError::Std)
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct ContractInfoV1 {
+    pub name: String,
+    pub bind_name: String,
+    pub base_denom: String,
+    pub convertible_base_denoms: Vec<String>,
+    pub supported_quote_denoms: Vec<String>,
+    pub approvers: Vec<Addr>,
+    pub executors: Vec<Addr>,
+    pub ask_required_attributes: Vec<String>,
+    pub bid_required_attributes: Vec<String>,
+    pub price_precision: Uint128,
+    pub size_increment: Uint128,
 }
 
-pub fn get_contract_info(store: &dyn Storage) -> StdResult<ContractInfo> {
-    CONTRACT_INFO.load(store)
+#[allow(deprecated)]
+impl From<ContractInfo> for ContractInfoV1 {
+    fn from(contract_info: ContractInfo) -> Self {
+        ContractInfoV1 {
+            name: contract_info.name,
+            bind_name: contract_info.bind_name,
+            base_denom: contract_info.base_denom,
+            convertible_base_denoms: contract_info.convertible_base_denoms,
+            supported_quote_denoms: contract_info.supported_quote_denoms,
+            approvers: vec![],
+            executors: contract_info.executors,
+            ask_required_attributes: contract_info.ask_required_attributes,
+            bid_required_attributes: contract_info.bid_required_attributes,
+            price_precision: contract_info.price_precision,
+            size_increment: contract_info.size_increment,
+        }
+    }
+}
+
+pub fn set_contract_info(
+    store: &mut dyn Storage,
+    contract_info: &ContractInfoV1,
+) -> Result<(), ContractError> {
+    CONTRACT_INFO_V1
+        .save(store, &contract_info)
+        .map_err(ContractError::Std)
+}
+
+pub fn get_contract_info(store: &dyn Storage) -> Result<ContractInfoV1, ContractError> {
+    CONTRACT_INFO_V1.load(store).map_err(ContractError::Std)
+}
+
+pub fn migrate_contract_info(
+    store: &mut dyn Storage,
+    api: &dyn Api,
+    msg: MigrateMsg,
+) -> Result<ContractInfoV1, ContractError> {
+    let version_info_result = get_version_info(store);
+    let current_version = match version_info_result {
+        Ok(version_info) => Version::parse(&version_info.version)?,
+        // version support added in 0.15.0, all previous versions used ContractInfo for version tracking
+        // if VersionInfo doesn't exist, try ContractInfo
+        _ => match CONTRACT_INFO.load(store) {
+            #[allow(deprecated)]
+            Ok(contract_info) => Version::parse(&contract_info.version)?,
+            Err(_) => {
+                return Err(ContractError::UnsupportedUpgrade {
+                    source_version: "UNKNOWN".to_string(),
+                    target_version: PACKAGE_VERSION.into(),
+                })
+            }
+        },
+    };
+
+    // version support added in 0.15.0, all previous versions migrate to v1 of state data
+    let upgrade_req = VersionReq::parse("<0.15.0")?;
+
+    if upgrade_req.matches(&current_version) {
+        let mut contract_info_v1: ContractInfoV1 = CONTRACT_INFO.load(store)?.into();
+
+        for approver in msg.approvers {
+            contract_info_v1
+                .approvers
+                .push(api.addr_validate(&approver)?)
+        }
+
+        set_contract_info(store, &contract_info_v1)?;
+    }
+
+    get_contract_info(store)
 }
 
 #[cfg(test)]
 mod tests {
     use provwasm_mocks::mock_dependencies;
 
-    use crate::contract_info::{get_contract_info, set_contract_info, ContractInfo};
+    #[allow(deprecated)]
+    use crate::contract_info::{
+        get_contract_info, migrate_contract_info, set_contract_info, ContractInfo, ContractInfoV1,
+        CONTRACT_INFO,
+    };
+    use crate::msg::MigrateMsg;
     use cosmwasm_std::{Addr, Uint128};
 
     #[test]
@@ -52,17 +137,14 @@ mod tests {
         let mut deps = mock_dependencies(&[]);
         let result = set_contract_info(
             &mut deps.storage,
-            &ContractInfo {
+            &ContractInfoV1 {
                 name: "contract_name".into(),
-                definition: "def".to_string(),
-                version: "ver".to_string(),
                 bind_name: "contract_bind_name".into(),
                 base_denom: "base_denom".into(),
                 convertible_base_denoms: vec!["con_base_1".into(), "con_base_2".into()],
                 supported_quote_denoms: vec!["quo_base_1".into(), "quo_base_2".into()],
                 approvers: vec![Addr::unchecked("approver_1"), Addr::unchecked("approver_2")],
                 executors: vec![Addr::unchecked("exec_1"), Addr::unchecked("exec_2")],
-                issuers: vec![Addr::unchecked("issuer_1"), Addr::unchecked("issuer_2")],
                 ask_required_attributes: vec!["ask_tag_1".into(), "ask_tag_2".into()],
                 bid_required_attributes: vec!["ask_tag_1".into(), "ask_tag_2".into()],
                 price_precision: Uint128(3),
@@ -78,8 +160,6 @@ mod tests {
         match contract_info {
             Ok(contract_info) => {
                 assert_eq!(contract_info.name, "contract_name");
-                assert_eq!(contract_info.definition, "def");
-                assert_eq!(contract_info.version, "ver");
                 assert_eq!(contract_info.bind_name, "contract_bind_name");
                 assert_eq!(contract_info.base_denom, "base_denom");
                 assert_eq!(
@@ -99,10 +179,6 @@ mod tests {
                     vec![Addr::unchecked("exec_1"), Addr::unchecked("exec_2")]
                 );
                 assert_eq!(
-                    contract_info.issuers,
-                    vec![Addr::unchecked("issuer_1"), Addr::unchecked("issuer_2")]
-                );
-                assert_eq!(
                     contract_info.ask_required_attributes,
                     vec!["ask_tag_1", "ask_tag_2"]
                 );
@@ -114,6 +190,122 @@ mod tests {
                 assert_eq!(contract_info.size_increment, Uint128(1000));
             }
             result => panic!("unexpected error: {:?}", result),
+        }
+    }
+
+    #[test]
+    #[allow(deprecated)]
+    fn pre_0_15_0_migrate_with_existing_issuers() {
+        // setup
+        let mut deps = mock_dependencies(&[]);
+
+        let _ = CONTRACT_INFO.save(
+            &mut deps.storage,
+            &ContractInfo {
+                name: "contract_name".into(),
+                definition: "contract_def".to_string(),
+                version: "0.0.1".to_string(),
+                bind_name: "contract_bind_name".into(),
+                base_denom: "base_denom".into(),
+                convertible_base_denoms: vec!["con_base_1".into(), "con_base_2".into()],
+                supported_quote_denoms: vec!["quote_1".into(), "quote_2".into()],
+                approvers: vec![],
+                executors: vec![Addr::unchecked("exec_1"), Addr::unchecked("exec_2")],
+                issuers: vec![Addr::unchecked("issuer_1"), Addr::unchecked("issuer_2")],
+                ask_required_attributes: vec!["ask_tag_1".into(), "ask_tag_2".into()],
+                bid_required_attributes: vec!["bid_tag_1".into(), "bid_tag_2".into()],
+                price_precision: Uint128(2),
+                size_increment: Uint128(100),
+            },
+        );
+
+        // migrate without approvers
+        let migrate_response = migrate_contract_info(
+            &mut deps.storage,
+            &deps.api,
+            MigrateMsg { approvers: vec![] },
+        );
+
+        match migrate_response {
+            Ok(_) => {
+                // verify contract_info updated
+                let contract_info = get_contract_info(&deps.storage).unwrap();
+                let expected_contract_info = ContractInfoV1 {
+                    name: "contract_name".into(),
+                    bind_name: "contract_bind_name".into(),
+                    base_denom: "base_denom".into(),
+                    convertible_base_denoms: vec!["con_base_1".into(), "con_base_2".into()],
+                    supported_quote_denoms: vec!["quote_1".into(), "quote_2".into()],
+                    approvers: vec![],
+                    executors: vec![Addr::unchecked("exec_1"), Addr::unchecked("exec_2")],
+                    ask_required_attributes: vec!["ask_tag_1".into(), "ask_tag_2".into()],
+                    bid_required_attributes: vec!["bid_tag_1".into(), "bid_tag_2".into()],
+                    price_precision: Uint128(2),
+                    size_increment: Uint128(100),
+                };
+
+                assert_eq!(contract_info, expected_contract_info)
+            }
+            Err(error) => panic!("unexpected error: {:?}", error),
+        }
+    }
+
+    #[test]
+    #[allow(deprecated)]
+    fn pre_0_15_0_migrate_with_approvers() {
+        // setup
+        let mut deps = mock_dependencies(&[]);
+
+        let _ = CONTRACT_INFO.save(
+            &mut deps.storage,
+            &ContractInfo {
+                name: "contract_name".into(),
+                definition: "contract_definition".to_string(),
+                version: "0.14.1".to_string(),
+                bind_name: "contract_bind_name".into(),
+                base_denom: "base_denom".into(),
+                convertible_base_denoms: vec!["con_base_1".into(), "con_base_2".into()],
+                supported_quote_denoms: vec!["quote_1".into(), "quote_2".into()],
+                approvers: vec![],
+                executors: vec![Addr::unchecked("exec_1"), Addr::unchecked("exec_2")],
+                issuers: vec![Addr::unchecked("issuer_1"), Addr::unchecked("issuer_2")],
+                ask_required_attributes: vec!["ask_tag_1".into(), "ask_tag_2".into()],
+                bid_required_attributes: vec!["bid_tag_1".into(), "bid_tag_2".into()],
+                price_precision: Uint128(2),
+                size_increment: Uint128(100),
+            },
+        );
+
+        // migrate with approvers
+        let migrate_response = migrate_contract_info(
+            &mut deps.storage,
+            &deps.api,
+            MigrateMsg {
+                approvers: vec!["approver_1".into(), "approver_2".into()],
+            },
+        );
+
+        match migrate_response {
+            Ok(_) => {
+                // verify contract_info updated
+                let contract_info = get_contract_info(&deps.storage).unwrap();
+                let expected_contract_info = ContractInfoV1 {
+                    name: "contract_name".into(),
+                    bind_name: "contract_bind_name".into(),
+                    base_denom: "base_denom".into(),
+                    convertible_base_denoms: vec!["con_base_1".into(), "con_base_2".into()],
+                    supported_quote_denoms: vec!["quote_1".into(), "quote_2".into()],
+                    approvers: vec![Addr::unchecked("approver_1"), Addr::unchecked("approver_2")],
+                    executors: vec![Addr::unchecked("exec_1"), Addr::unchecked("exec_2")],
+                    ask_required_attributes: vec!["ask_tag_1".into(), "ask_tag_2".into()],
+                    bid_required_attributes: vec!["bid_tag_1".into(), "bid_tag_2".into()],
+                    price_precision: Uint128(2),
+                    size_increment: Uint128(100),
+                };
+
+                assert_eq!(contract_info, expected_contract_info)
+            }
+            Err(error) => panic!("unexpected error: {:?}", error),
         }
     }
 }

--- a/src/contract_info.rs
+++ b/src/contract_info.rs
@@ -99,7 +99,7 @@ pub fn set_legacy_contract_info(
 pub fn migrate_contract_info(
     store: &mut dyn Storage,
     api: &dyn Api,
-    msg: MigrateMsg,
+    msg: &MigrateMsg,
 ) -> Result<ContractInfoV1, ContractError> {
     let version_info = get_version_info(store)?;
     let current_version = Version::parse(&version_info.version)?;
@@ -110,7 +110,7 @@ pub fn migrate_contract_info(
     if upgrade_req.matches(&current_version) {
         let mut contract_info_v1: ContractInfoV1 = CONTRACT_INFO.load(store)?.into();
 
-        for approver in msg.approvers {
+        for approver in &msg.approvers {
             contract_info_v1
                 .approvers
                 .push(api.addr_validate(&approver)?)
@@ -225,7 +225,7 @@ mod tests {
         let migrate_response = migrate_contract_info(
             &mut deps.storage,
             &deps.api,
-            MigrateMsg { approvers: vec![] },
+            &MigrateMsg { approvers: vec![] },
         );
 
         match migrate_response {
@@ -282,7 +282,7 @@ mod tests {
         let migrate_response = migrate_contract_info(
             &mut deps.storage,
             &deps.api,
-            MigrateMsg {
+            &MigrateMsg {
                 approvers: vec!["approver_1".into(), "approver_2".into()],
             },
         );

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,4 +1,5 @@
 use cosmwasm_std::StdError;
+use semver::Error as SemverError;
 use serde_json::Error;
 use thiserror::Error;
 
@@ -54,6 +55,9 @@ pub enum ContractError {
 
     #[error("{0}")]
     JsonSerde(#[from] Error),
+
+    #[error("{0}")]
+    SemverError(#[from] SemverError),
 
     #[error("Total (price * size) exceeds max allowed")]
     TotalOverflow,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,3 +3,4 @@ pub mod contract_info;
 pub mod error;
 pub mod msg;
 pub mod state;
+pub mod version_info;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
+pub mod ask_order;
+pub mod bid_order;
 pub mod contract;
 pub mod contract_info;
 pub mod error;
 pub mod msg;
-pub mod state;
 pub mod version_info;

--- a/src/msg.rs
+++ b/src/msg.rs
@@ -90,6 +90,8 @@ pub enum ExecuteMsg {
         id: String,
         base: String,
         price: String,
+        quote: String,
+        quote_size: Uint128,
         size: Uint128,
     },
     ExecuteMatch {
@@ -155,6 +157,8 @@ impl Validate for ExecuteMsg {
                 id,
                 base,
                 price,
+                quote,
+                quote_size,
                 size,
             } => {
                 if Uuid::parse_str(id).is_err() {
@@ -165,6 +169,12 @@ impl Validate for ExecuteMsg {
                 }
                 if price.is_empty() {
                     invalid_fields.push("price");
+                }
+                if quote.is_empty() {
+                    invalid_fields.push("quote");
+                }
+                if quote_size.lt(&Uint128(1)) {
+                    invalid_fields.push("quote_size");
                 }
                 if size.lt(&Uint128(1)) {
                     invalid_fields.push("size");

--- a/src/msg.rs
+++ b/src/msg.rs
@@ -13,7 +13,6 @@ pub struct InstantiateMsg {
     pub supported_quote_denoms: Vec<String>,
     pub approvers: Vec<String>,
     pub executors: Vec<String>,
-    pub issuers: Vec<String>,
     pub ask_required_attributes: Vec<String>,
     pub bid_required_attributes: Vec<String>,
     pub price_precision: Uint128,
@@ -195,6 +194,7 @@ pub enum QueryMsg {
     GetAsk { id: String },
     GetBid { id: String },
     GetContractInfo {},
+    GetVersionInfo {},
 }
 
 impl Validate for QueryMsg {
@@ -224,6 +224,7 @@ impl Validate for QueryMsg {
                 }
             }
             QueryMsg::GetContractInfo {} => {}
+            QueryMsg::GetVersionInfo {} => {}
         }
 
         match invalid_fields.len() {
@@ -237,8 +238,8 @@ impl Validate for QueryMsg {
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
 #[serde(rename_all = "snake_case")]
-pub enum MigrateMsg {
-    Migrate { approvers: Vec<String> },
+pub struct MigrateMsg {
+    pub approvers: Vec<String>,
 }
 
 impl Validate for MigrateMsg {

--- a/src/msg.rs
+++ b/src/msg.rs
@@ -70,6 +70,8 @@ impl Validate for InstantiateMsg {
 pub enum ExecuteMsg {
     ApproveAsk {
         id: String,
+        base: String,
+        size: Uint128,
     },
     CancelAsk {
         id: String,
@@ -79,8 +81,10 @@ pub enum ExecuteMsg {
     },
     CreateAsk {
         id: String,
+        base: String,
         quote: String,
         price: String,
+        size: Uint128,
     },
     CreateBid {
         id: String,
@@ -113,20 +117,38 @@ impl Validate for ExecuteMsg {
         let mut invalid_fields: Vec<&str> = vec![];
 
         match self {
-            ExecuteMsg::ApproveAsk { id } => {
+            ExecuteMsg::ApproveAsk { id, base, size } => {
                 if Uuid::parse_str(id).is_err() {
                     invalid_fields.push("id");
                 }
+                if base.is_empty() {
+                    invalid_fields.push("base");
+                }
+                if size.lt(&Uint128(1)) {
+                    invalid_fields.push("size");
+                }
             }
-            ExecuteMsg::CreateAsk { id, quote, price } => {
+            ExecuteMsg::CreateAsk {
+                id,
+                base,
+                quote,
+                price,
+                size,
+            } => {
                 if Uuid::parse_str(id).is_err() {
                     invalid_fields.push("id");
+                }
+                if base.is_empty() {
+                    invalid_fields.push("base");
+                }
+                if quote.is_empty() {
+                    invalid_fields.push("quote");
                 }
                 if price.is_empty() {
                     invalid_fields.push("price");
                 }
-                if quote.is_empty() {
-                    invalid_fields.push("quote");
+                if size.lt(&Uint128(1)) {
+                    invalid_fields.push("size");
                 }
             }
             ExecuteMsg::CreateBid {

--- a/src/state.rs
+++ b/src/state.rs
@@ -1,6 +1,10 @@
-use cosmwasm_std::{Addr, Coin, Storage, Uint128};
+use crate::error::ContractError;
+use crate::msg::MigrateMsg;
+use crate::version_info::get_version_info;
+use cosmwasm_std::{Addr, Api, Coin, Order, Storage, Uint128};
 use cosmwasm_storage::{bucket, bucket_read, Bucket, ReadonlyBucket};
 use schemars::JsonSchema;
+use semver::{Version, VersionReq};
 use serde::{Deserialize, Serialize};
 
 pub static NAMESPACE_ORDER_ASK: &[u8] = b"ask";
@@ -22,6 +26,7 @@ pub enum AskOrderClass {
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+#[deprecated(since = "0.15.0")]
 pub struct AskOrder {
     pub base: Coin,
     pub class: AskOrderClass,
@@ -30,6 +35,32 @@ pub struct AskOrder {
     pub price: String,
     pub quote: String,
     pub size: Uint128,
+}
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct AskOrderV1 {
+    pub id: String,
+    pub owner: Addr,
+    pub class: AskOrderClass,
+    pub base: String,
+    pub quote: String,
+    pub price: String,
+    pub size: Uint128,
+}
+
+#[allow(deprecated)]
+impl From<AskOrder> for AskOrderV1 {
+    fn from(ask_order: AskOrder) -> Self {
+        AskOrderV1 {
+            id: ask_order.id,
+            owner: ask_order.owner,
+            class: ask_order.class,
+            base: ask_order.base.denom,
+            quote: ask_order.quote,
+            price: ask_order.price,
+            size: ask_order.base.amount,
+        }
+    }
 }
 
 #[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
@@ -42,17 +73,137 @@ pub struct BidOrder {
     pub size: Uint128,
 }
 
-pub fn get_ask_storage(storage: &mut dyn Storage) -> Bucket<AskOrder> {
+#[allow(deprecated)]
+pub fn migrate_ask_orders(
+    store: &mut dyn Storage,
+    _api: &dyn Api,
+    _msg: MigrateMsg,
+) -> Result<(), ContractError> {
+    let version_info = get_version_info(store)?;
+    let current_version = Version::parse(&version_info.version)?;
+
+    // version support added in 0.15.0, all previous versions migrate to v1 of state data
+    let upgrade_req = VersionReq::parse("<0.15.0")?;
+
+    if upgrade_req.matches(&current_version) {
+        let legacy_ask_storage: Bucket<AskOrder> = bucket(store, NAMESPACE_ORDER_ASK);
+
+        let migrated_ask_orders: Vec<Result<(Vec<u8>, AskOrderV1), ContractError>> =
+            legacy_ask_storage
+                .range(None, None, Order::Ascending)
+                .map(|kv_ask| -> Result<(Vec<u8>, AskOrderV1), ContractError> {
+                    let (ask_key, ask) = kv_ask?;
+                    Ok((ask_key, ask.into()))
+                })
+                .collect();
+
+        let mut ask_storage = get_ask_storage(store);
+        for migrated_ask_order in migrated_ask_orders {
+            let (ask_key, ask) = migrated_ask_order?;
+            ask_storage.save(&ask_key, &ask)?
+        }
+    }
+
+    Ok(())
+}
+
+#[allow(deprecated)]
+pub fn get_legacy_ask_storage(storage: &mut dyn Storage) -> Bucket<AskOrder> {
     bucket(storage, NAMESPACE_ORDER_ASK)
 }
 
-pub fn get_ask_storage_read(storage: &dyn Storage) -> ReadonlyBucket<AskOrder> {
+pub fn get_ask_storage(storage: &mut dyn Storage) -> Bucket<AskOrderV1> {
+    bucket(storage, NAMESPACE_ORDER_ASK)
+}
+
+pub fn get_ask_storage_read(storage: &dyn Storage) -> ReadonlyBucket<AskOrderV1> {
     bucket_read(storage, NAMESPACE_ORDER_ASK)
 }
+
 pub fn get_bid_storage(storage: &mut dyn Storage) -> Bucket<BidOrder> {
     bucket(storage, NAMESPACE_ORDER_BID)
 }
 
 pub fn get_bid_storage_read(storage: &dyn Storage) -> ReadonlyBucket<BidOrder> {
     bucket_read(storage, NAMESPACE_ORDER_BID)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::contract_info::set_legacy_contract_info;
+    use crate::error::ContractError;
+    use crate::msg::MigrateMsg;
+    use crate::state::{
+        get_ask_storage_read, migrate_ask_orders, AskOrderClass, AskOrderV1, NAMESPACE_ORDER_ASK,
+    };
+    use crate::{contract_info, state};
+    use cosmwasm_std::{coin, Addr, Uint128};
+    use cosmwasm_storage::{bucket, Bucket};
+    use provwasm_mocks::mock_dependencies;
+
+    #[test]
+    #[allow(deprecated)]
+    pub fn migrate_legacy_ask_to_v1() -> Result<(), ContractError> {
+        let mut deps = mock_dependencies(&[]);
+
+        set_legacy_contract_info(
+            &mut deps.storage,
+            &contract_info::ContractInfo {
+                name: "contract_name".to_string(),
+                definition: "contract_def".to_string(),
+                version: "0.14.99".to_string(),
+                bind_name: "bind_name".to_string(),
+                base_denom: "base_1".to_string(),
+                convertible_base_denoms: vec![],
+                supported_quote_denoms: vec![],
+                approvers: vec![],
+                executors: vec![],
+                issuers: vec![],
+                ask_required_attributes: vec![],
+                bid_required_attributes: vec![],
+                price_precision: Uint128(2),
+                size_increment: Uint128(100),
+            },
+        )?;
+
+        let mut legacy_ask_storage: Bucket<state::AskOrder> =
+            bucket(&mut deps.storage, NAMESPACE_ORDER_ASK);
+
+        legacy_ask_storage.save(
+            b"id",
+            &state::AskOrder {
+                base: coin(100, "base_1"),
+                class: AskOrderClass::Basic,
+                id: "id".to_string(),
+                owner: Addr::unchecked("asker"),
+                price: "10".to_string(),
+                quote: "quote_1".to_string(),
+                size: Uint128(100),
+            },
+        )?;
+
+        migrate_ask_orders(
+            &mut deps.storage,
+            &deps.api,
+            MigrateMsg { approvers: vec![] },
+        )?;
+
+        let ask_storage = get_ask_storage_read(&deps.storage);
+        let migrated_ask = ask_storage.load(b"id")?;
+
+        assert_eq!(
+            migrated_ask,
+            AskOrderV1 {
+                id: "id".to_string(),
+                owner: Addr::unchecked("asker"),
+                class: AskOrderClass::Basic,
+                base: "base_1".to_string(),
+                quote: "quote_1".to_string(),
+                price: "10".to_string(),
+                size: Uint128(100)
+            }
+        );
+
+        Ok(())
+    }
 }

--- a/src/version_info.rs
+++ b/src/version_info.rs
@@ -1,3 +1,4 @@
+use crate::contract_info::get_legacy_contract_info;
 use crate::error::ContractError;
 use cosmwasm_std::Storage;
 use cw_storage_plus::Item;
@@ -25,7 +26,23 @@ pub fn set_version_info(
 }
 
 pub fn get_version_info(store: &dyn Storage) -> Result<VersionInfoV1, ContractError> {
-    VERSION_INFO.load(store).map_err(ContractError::Std)
+    let version_info_result = VERSION_INFO.load(store).map_err(ContractError::Std);
+    match &version_info_result {
+        Ok(_) => (version_info_result),
+        // version support added in 0.15.0, all previous versions used ContractInfo for version tracking
+        // if VersionInfo doesn't exist, try ContractInfo
+        Err(_) => match get_legacy_contract_info(store) {
+            #[allow(deprecated)]
+            Ok(contract_info) => Ok(VersionInfoV1 {
+                definition: contract_info.definition,
+                version: contract_info.version,
+            }),
+            Err(_) => Err(ContractError::UnsupportedUpgrade {
+                source_version: "UNKNOWN".to_string(),
+                target_version: PACKAGE_VERSION.into(),
+            }),
+        },
+    }
 }
 
 pub fn migrate_version_info(store: &mut dyn Storage) -> Result<VersionInfoV1, ContractError> {
@@ -41,9 +58,12 @@ pub fn migrate_version_info(store: &mut dyn Storage) -> Result<VersionInfoV1, Co
 
 #[cfg(test)]
 mod tests {
-    use crate::version_info::{get_version_info, set_version_info, VersionInfoV1};
+    use crate::contract_info;
+    use crate::contract_info::set_legacy_contract_info;
+    use crate::error::ContractError;
+    use crate::version_info::{get_version_info, set_version_info, VersionInfoV1, PACKAGE_VERSION};
+    use cosmwasm_std::Uint128;
     use provwasm_mocks::mock_dependencies;
-    use std::cmp::Ordering;
 
     #[test]
     pub fn set_version_info_with_valid_data() {
@@ -65,9 +85,69 @@ mod tests {
             Ok(version_info) => {
                 assert_eq!(version_info.definition, "def");
                 assert_eq!(version_info.version, "0.14");
-                assert_eq!(version_info.version.cmp(&"0.14.10".into()), Ordering::Less);
             }
             result => panic!("unexpected error: {:?}", result),
         }
+    }
+
+    #[test]
+    pub fn get_version_info_pre_0_15_0() -> Result<(), ContractError> {
+        let mut deps = mock_dependencies(&[]);
+
+        #[allow(deprecated)]
+        set_legacy_contract_info(
+            &mut deps.storage,
+            &contract_info::ContractInfo {
+                name: "contract_name".into(),
+                definition: "contract_def".to_string(),
+                version: "0.14.99".to_string(),
+                bind_name: "bind_name".to_string(),
+                base_denom: "base_1".to_string(),
+                convertible_base_denoms: vec![],
+                supported_quote_denoms: vec![],
+                approvers: vec![],
+                executors: vec![],
+                issuers: vec![],
+                ask_required_attributes: vec![],
+                bid_required_attributes: vec![],
+                price_precision: Uint128(2),
+                size_increment: Uint128(100),
+            },
+        )?;
+
+        let version_info = get_version_info(&deps.storage);
+        match version_info {
+            Ok(version_info) => {
+                assert_eq!(version_info.definition, "contract_def");
+                assert_eq!(version_info.version, "0.14.99");
+            }
+            result => panic!("unexpected error: {:?}", result),
+        }
+
+        Ok(())
+    }
+
+    #[test]
+    pub fn get_version_info_unknown() -> Result<(), ContractError> {
+        let deps = mock_dependencies(&[]);
+
+        let version_info = get_version_info(&deps.storage);
+        match version_info {
+            Ok(_) => {
+                panic!("expected error, but ok")
+            }
+            Err(error) => match error {
+                ContractError::UnsupportedUpgrade {
+                    source_version,
+                    target_version,
+                } => {
+                    assert_eq!(source_version, "UNKNOWN");
+                    assert_eq!(target_version, PACKAGE_VERSION)
+                }
+                _ => panic!("unexpected error: {:?}", error),
+            },
+        }
+
+        Ok(())
     }
 }

--- a/src/version_info.rs
+++ b/src/version_info.rs
@@ -1,0 +1,73 @@
+use crate::error::ContractError;
+use cosmwasm_std::Storage;
+use cw_storage_plus::Item;
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+pub const CRATE_NAME: &str = env!("CARGO_CRATE_NAME");
+pub const PACKAGE_VERSION: &str = env!("CARGO_PKG_VERSION");
+const VERSION_INFO_NAMESPACE: &str = "version_info";
+const VERSION_INFO: Item<VersionInfoV1> = Item::new(VERSION_INFO_NAMESPACE);
+
+#[derive(Serialize, Deserialize, Clone, Debug, PartialEq, JsonSchema)]
+pub struct VersionInfoV1 {
+    pub definition: String,
+    pub version: String,
+}
+
+pub fn set_version_info(
+    store: &mut dyn Storage,
+    version_info: &VersionInfoV1,
+) -> Result<(), ContractError> {
+    VERSION_INFO
+        .save(store, &version_info)
+        .map_err(ContractError::Std)
+}
+
+pub fn get_version_info(store: &dyn Storage) -> Result<VersionInfoV1, ContractError> {
+    VERSION_INFO.load(store).map_err(ContractError::Std)
+}
+
+pub fn migrate_version_info(store: &mut dyn Storage) -> Result<VersionInfoV1, ContractError> {
+    let version_info = VersionInfoV1 {
+        definition: CRATE_NAME.to_string(),
+        version: PACKAGE_VERSION.to_string(),
+    };
+
+    set_version_info(store, &version_info)?;
+
+    Ok(version_info)
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::version_info::{get_version_info, set_version_info, VersionInfoV1};
+    use provwasm_mocks::mock_dependencies;
+    use std::cmp::Ordering;
+
+    #[test]
+    pub fn set_version_info_with_valid_data() {
+        let mut deps = mock_dependencies(&[]);
+        let result = set_version_info(
+            &mut deps.storage,
+            &VersionInfoV1 {
+                definition: "def".to_string(),
+                version: "0.14".to_string(),
+            },
+        );
+        match result {
+            Ok(()) => {}
+            result => panic!("unexpected error: {:?}", result),
+        }
+
+        let version_info = get_version_info(&deps.storage);
+        match version_info {
+            Ok(version_info) => {
+                assert_eq!(version_info.definition, "def");
+                assert_eq!(version_info.version, "0.14");
+                assert_eq!(version_info.version.cmp(&"0.14.10".into()), Ordering::Less);
+            }
+            result => panic!("unexpected error: {:?}", result),
+        }
+    }
+}


### PR DESCRIPTION
closes #7 

schema changes for ask, bid, and approve_ask messages:

```
    CreateAsk {
        id: String,
        base: String,
        quote: String,
        price: String,
        size: Uint128,
    }

    CreateBid {
        id: String,
        base: String,
        quote: String,
        price: String,
        size: Uint128,
    }

    ApproveAsk {
        id: String,
        base: String,
        size: Uint128,
    }
```
