### PR TITLE
add fee feature

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
 name = "ats-smart-contract"
-version = "0.15.0"
+version = "0.15.2"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ats-smart-contract"
-version = "0.15.0"
+version = "0.15.2"
 authors = ["Ken Talley <ktalley@figure.com>"]
 edition = "2018"
 
@@ -32,7 +32,7 @@ cosmwasm-std = { version = "0.14.1" }
 cosmwasm-storage = { version = "0.14.1", features = ["iterator"] }
 cw-storage-plus = { version = "0.6.0" }
 provwasm-std = { version = "0.14.1" }
-rust_decimal = { version = "1.12.2" }
+rust_decimal = { version = "1.14" }
 schemars = "0.8.1"
 semver = "1.0.3"
 serde = { version = "1.0.103", default-features = false, features = ["derive"] }

--- a/schema/contract_info_v1.json
+++ b/schema/contract_info_v1.json
@@ -1,6 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
   "title": "ContractInfoV1",
+  "deprecated": true,
   "type": "object",
   "required": [
     "approvers",

--- a/schema/instantiate_msg.json
+++ b/schema/instantiate_msg.json
@@ -52,6 +52,18 @@
         "type": "string"
       }
     },
+    "fee_account": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "fee_rate": {
+      "type": [
+        "string",
+        "null"
+      ]
+    },
     "name": {
       "type": "string"
     },

--- a/src/ask_order.rs
+++ b/src/ask_order.rs
@@ -167,7 +167,11 @@ mod tests {
         migrate_ask_orders(
             &mut deps.storage,
             &deps.api,
-            &MigrateMsg { approvers: vec![] },
+            &MigrateMsg {
+                approvers: None,
+                fee_rate: None,
+                fee_account: None,
+            },
         )?;
 
         let ask_storage = get_ask_storage_read(&deps.storage);

--- a/src/bid_order.rs
+++ b/src/bid_order.rs
@@ -147,7 +147,11 @@ mod tests {
         migrate_bid_orders(
             &mut deps.storage,
             &deps.api,
-            &MigrateMsg { approvers: vec![] },
+            &MigrateMsg {
+                approvers: None,
+                fee_rate: None,
+                fee_account: None,
+            },
         )?;
 
         let bid_storage = get_bid_storage_read(&deps.storage);


### PR DESCRIPTION
closes #5 

### new fields
```
pub struct InstantiateMsg {
    pub fee_rate: Option<String>,
    pub fee_account: Option<String>,
}

pub struct MigrateMsg {
    pub approvers: Option<Vec<String>>,
    pub fee_rate: Option<String>,
    pub fee_account: Option<String>,
}
```
`fee_rate` and `fee_account` are optional fields in the instantiate and migrate messages. approvers is also optional in the migrate message.

**fees distributed are in the quote denom**

fees will be calculated during the execute match function, deducted from the quote amount sent to the seller, and sent to the `fee_account` address.

the fee total is added as information to the execute match response attributes with the key `fee`