### PR TITLE
issue 80: Allow a message to be sent to update contract config

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -10,7 +10,7 @@ checksum = "23b62fc65de8e4e7f52534fb52b0f3ed04746ae267519eef2a83941e8085068b"
 
 [[package]]
 name = "ats-smart-contract"
-version = "0.17.0"
+version = "0.17.1"
 dependencies = [
  "cosmwasm-schema",
  "cosmwasm-std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ats-smart-contract"
-version = "0.17.0"
+version = "0.17.1"
 authors = ["Ken Talley <ktalley@figure.com>"]
 edition = "2018"
 

--- a/schema/execute_msg.json
+++ b/schema/execute_msg.json
@@ -287,6 +287,80 @@
         }
       },
       "additionalProperties": false
+    },
+    {
+      "type": "object",
+      "required": [
+        "modify_contract"
+      ],
+      "properties": {
+        "modify_contract": {
+          "type": "object",
+          "properties": {
+            "approvers": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": "string"
+              }
+            },
+            "ask_fee_account": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "ask_fee_rate": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "ask_required_attributes": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": "string"
+              }
+            },
+            "bid_fee_account": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "bid_fee_rate": {
+              "type": [
+                "string",
+                "null"
+              ]
+            },
+            "bid_required_attributes": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": "string"
+              }
+            },
+            "executors": {
+              "type": [
+                "array",
+                "null"
+              ],
+              "items": {
+                "type": "string"
+              }
+            }
+          }
+        }
+      },
+      "additionalProperties": false
     }
   ],
   "definitions": {

--- a/src/contract.rs
+++ b/src/contract.rs
@@ -1,6 +1,6 @@
 use cosmwasm_std::{
     attr, coin, coins, entry_point, to_binary, Addr, BankMsg, Binary, Coin, Deps, DepsMut, Env,
-    MessageInfo, Response, StdError, StdResult, Uint128,
+    MessageInfo, Order, Pair, Response, StdError, StdResult, Uint128,
 };
 use provwasm_std::{
     bind_name, transfer_marker_coins, Marker, MarkerType, NameBinding, ProvenanceMsg,
@@ -14,11 +14,12 @@ use crate::ask_order::{
 use crate::bid_order::{get_bid_storage, get_bid_storage_read, migrate_bid_orders, BidOrderV2};
 use crate::common::{Action, Event, FeeInfo};
 use crate::contract_info::{
-    get_contract_info, migrate_contract_info, set_contract_info, ContractInfoV3,
+    get_contract_info, migrate_contract_info, modify_contract_info, set_contract_info,
+    ContractInfoV3,
 };
 use crate::error::ContractError;
 use crate::error::ContractError::InvalidPricePrecisionSizePair;
-use crate::msg::{ExecuteMsg, InstantiateMsg, MigrateMsg, QueryMsg, Validate};
+use crate::msg::{ExecuteMsg, InstantiateMsg, MigrateMsg, ModifyMsg, QueryMsg, Validate};
 use crate::version_info::{
     get_version_info, migrate_version_info, set_version_info, VersionInfoV1, CRATE_NAME,
     PACKAGE_VERSION,
@@ -220,6 +221,30 @@ pub fn execute(
         ExecuteMsg::RejectBid { id, size } => {
             reverse_bid(deps, env, info, id, String::from("reject_bid"), size)
         }
+        ExecuteMsg::ModifyContract {
+            approvers,
+            executors,
+            ask_fee_rate,
+            ask_fee_account,
+            bid_fee_rate,
+            bid_fee_account,
+            ask_required_attributes,
+            bid_required_attributes,
+        } => modify_contract(
+            deps,
+            env,
+            &info,
+            ModifyMsg {
+                approvers,
+                executors,
+                ask_fee_rate,
+                ask_fee_account,
+                bid_fee_rate,
+                bid_fee_account,
+                ask_required_attributes,
+                bid_required_attributes,
+            },
+        ),
     }
 }
 
@@ -1105,6 +1130,92 @@ fn reverse_bid(
             response = response.add_attributes(vec![attr("order_open", "true")]);
         }
     }
+
+    Ok(response)
+}
+
+fn modify_contract(
+    deps: DepsMut<ProvenanceQuery>,
+    _env: Env,
+    info: &MessageInfo,
+    msg: ModifyMsg,
+) -> Result<Response<ProvenanceMsg>, ContractError> {
+    msg.validate()?;
+
+    let contract_info = get_contract_info(deps.storage)?;
+
+    if !contract_info.executors.contains(&info.sender) {
+        return Err(ContractError::Unauthorized);
+    }
+
+    let ask_storage = get_ask_storage_read(deps.storage);
+    let ask_orders: Vec<AskOrderV1> = ask_storage
+        .range(None, None, Order::Ascending)
+        .map(|kv_ask: StdResult<Pair<AskOrderV1>>| {
+            let (_, ask_order) = kv_ask.unwrap();
+            ask_order
+        })
+        .collect();
+    if !ask_orders.is_empty() {
+        match &msg.ask_required_attributes {
+            None => (),
+            Some(_) => {
+                return Err(ContractError::InvalidFields {
+                    fields: vec!["ask_required_attributes".to_string()],
+                });
+            }
+        }
+    }
+
+    let bid_storage = get_bid_storage_read(deps.storage);
+    let bid_orders: Vec<BidOrderV2> = bid_storage
+        .range(None, None, Order::Ascending)
+        .map(|kv_bid: StdResult<Pair<BidOrderV2>>| {
+            let (_, bid_order) = kv_bid.unwrap();
+            bid_order
+        })
+        .collect();
+    if !bid_orders.is_empty() {
+        match &msg.bid_required_attributes {
+            None => {}
+            Some(_) => {
+                return Err(ContractError::InvalidFields {
+                    fields: vec!["bid_required_attributes".to_string()],
+                });
+            }
+        }
+        match (&msg.bid_fee_rate, &msg.bid_fee_account) {
+            (None, None) => {}
+            (_, _) => {
+                return Err(ContractError::InvalidFields {
+                    fields: vec!["bid_fee".to_string()],
+                });
+            }
+        }
+    }
+
+    if !ask_orders.is_empty() || !bid_orders.is_empty() {
+        match &msg.approvers {
+            None => {}
+            Some(approvers) => {
+                let current_approvers: HashSet<String> = contract_info
+                    .approvers
+                    .into_iter()
+                    .map(|item| item.into_string())
+                    .collect();
+                let new_approvers: HashSet<String> = approvers.clone().into_iter().collect();
+                if !current_approvers.is_subset(&new_approvers) {
+                    return Err(ContractError::InvalidFields {
+                        fields: vec!["approvers".to_string()],
+                    });
+                }
+            }
+        }
+    }
+
+    modify_contract_info(deps, &msg)?;
+
+    let response = Response::new();
 
     Ok(response)
 }
@@ -11676,6 +11787,1684 @@ mod tests {
         assert!(bid_storage
             .load("c13f8888-ca43-4a64-ab1b-1ca8d60aa49b".as_bytes())
             .is_ok());
+    }
+
+    #[test]
+    fn execute_modify_contract_valid() {
+        let mut deps = mock_dependencies(&[]);
+
+        let version_info = set_version_info(
+            &mut deps.storage,
+            &VersionInfoV1 {
+                definition: "def".to_string(),
+                version: "0.16.2".to_string(),
+            },
+        );
+
+        match version_info {
+            Err(error) => panic!("unexpected error: {:?}", error),
+            Ok(_) => {}
+        }
+
+        setup_test_base(
+            &mut deps.storage,
+            &ContractInfoV3 {
+                name: "contract_name".into(),
+                bind_name: "contract_bind_name".into(),
+                base_denom: "base_denom".into(),
+                convertible_base_denoms: vec!["con_base_1".into(), "con_base_2".into()],
+                supported_quote_denoms: vec!["quote_1".into(), "quote_2".into()],
+                approvers: vec![Addr::unchecked("exec_1"), Addr::unchecked("exec_2")],
+                executors: vec![Addr::unchecked("exec_1"), Addr::unchecked("exec_2")],
+                ask_fee_info: None,
+                bid_fee_info: None,
+                ask_required_attributes: vec!["ask_tag_1".into(), "ask_tag_2".into()],
+                bid_required_attributes: vec!["bid_tag_1".into(), "bid_tag_2".into()],
+                price_precision: Uint128::new(2),
+                size_increment: Uint128::new(100),
+            },
+        );
+
+        let contract_info = get_contract_info(&deps.storage);
+        match contract_info {
+            Err(error) => panic!("unexpected error: {:?}", error),
+            Ok(contract_info) => {
+                assert_eq!(
+                    contract_info.executors,
+                    Vec::from([Addr::unchecked("exec_1"), Addr::unchecked("exec_2")])
+                );
+                assert_eq!(
+                    contract_info.convertible_base_denoms,
+                    vec!["con_base_1".to_string(), "con_base_2".to_string()]
+                );
+                assert_eq!(contract_info.ask_fee_info, None);
+            }
+        }
+
+        let exec_info = mock_info("exec_1", &[]);
+        let modify_contract_msg = ExecuteMsg::ModifyContract {
+            approvers: Some(vec!["approver_1".into(), "approver_3".into()]),
+            executors: Some(vec!["exec1".into(), "exec3".into()]),
+            ask_fee_rate: Some("0.123".into()),
+            ask_fee_account: Some("fee_acct_1".into()),
+            bid_fee_rate: Some("0.234".into()),
+            bid_fee_account: Some("fee_acct_2".into()),
+            ask_required_attributes: Some(vec!["ask_tag_1".into()]),
+            bid_required_attributes: Some(vec!["bid_tag_1".into(), "bid_tag_3".into()]),
+        };
+        let modify_contract_response =
+            execute(deps.as_mut(), mock_env(), exec_info, modify_contract_msg);
+        match modify_contract_response {
+            Ok(_) => {}
+            Err(error) => panic!("unexpected error: {:?}", error),
+        }
+
+        let contract_info = get_contract_info(&deps.storage);
+        match contract_info {
+            Err(error) => panic!("unexpected error: {:?}", error),
+            Ok(contract_info) => {
+                assert_eq!(
+                    contract_info.convertible_base_denoms,
+                    vec!["con_base_1".to_string(), "con_base_2".to_string()]
+                );
+                assert_eq!(
+                    contract_info.executors,
+                    Vec::from([Addr::unchecked("exec1"), Addr::unchecked("exec3")])
+                );
+                assert_eq!(
+                    contract_info.approvers,
+                    Vec::from([Addr::unchecked("approver_1"), Addr::unchecked("approver_3")])
+                );
+                assert_eq!(
+                    contract_info.ask_fee_info,
+                    Some(FeeInfo {
+                        account: Addr::unchecked("fee_acct_1"),
+                        rate: "0.123".into()
+                    })
+                );
+                assert_eq!(
+                    contract_info.bid_fee_info,
+                    Some(FeeInfo {
+                        account: Addr::unchecked("fee_acct_2"),
+                        rate: "0.234".into()
+                    })
+                );
+                assert_eq!(
+                    contract_info.ask_required_attributes,
+                    vec!["ask_tag_1".to_string()]
+                );
+                assert_eq!(
+                    contract_info.bid_required_attributes,
+                    vec!["bid_tag_1".to_string(), "bid_tag_3".to_string()]
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn execute_modify_contract_invalid_executor() {
+        let mut deps = mock_dependencies(&[]);
+
+        let version_info = set_version_info(
+            &mut deps.storage,
+            &VersionInfoV1 {
+                definition: "def".to_string(),
+                version: "0.16.1".to_string(),
+            },
+        );
+        match version_info {
+            Err(error) => panic!("unexpected error: {:?}", error),
+            Ok(_) => {}
+        }
+        setup_test_base(
+            &mut deps.storage,
+            &ContractInfoV3 {
+                name: "contract_name".into(),
+                bind_name: "contract_bind_name".into(),
+                base_denom: "base_denom".into(),
+                convertible_base_denoms: vec!["con_base_1".into(), "con_base_2".into()],
+                supported_quote_denoms: vec!["quote_1".into(), "quote_2".into()],
+                approvers: vec![Addr::unchecked("exec_1"), Addr::unchecked("exec_2")],
+                executors: vec![Addr::unchecked("exec_1"), Addr::unchecked("exec_2")],
+                ask_fee_info: None,
+                bid_fee_info: None,
+                ask_required_attributes: vec!["ask_tag_1".into(), "ask_tag_2".into()],
+                bid_required_attributes: vec!["bid_tag_1".into(), "bid_tag_2".into()],
+                price_precision: Uint128::new(2),
+                size_increment: Uint128::new(100),
+            },
+        );
+
+        let contract_info = get_contract_info(&deps.storage);
+        match contract_info {
+            Err(error) => panic!("unexpected error: {:?}", error),
+            Ok(contract_info) => {
+                assert_eq!(contract_info.ask_fee_info, None);
+                assert_eq!(
+                    contract_info.convertible_base_denoms,
+                    vec!["con_base_1".to_string(), "con_base_2".to_string()]
+                );
+                assert_eq!(
+                    contract_info.executors,
+                    Vec::from([Addr::unchecked("exec_1"), Addr::unchecked("exec_2")])
+                );
+                assert_eq!(
+                    contract_info.approvers,
+                    Vec::from([Addr::unchecked("exec_1"), Addr::unchecked("exec_2")])
+                );
+                assert_eq!(contract_info.ask_fee_info, None);
+                assert_eq!(contract_info.bid_fee_info, None);
+                assert_eq!(
+                    contract_info.ask_required_attributes,
+                    vec!["ask_tag_1".to_string(), "ask_tag_2".to_string()]
+                );
+                assert_eq!(
+                    contract_info.bid_required_attributes,
+                    vec!["bid_tag_1".to_string(), "bid_tag_2".to_string()]
+                );
+            }
+        }
+        let modify_contract_msg = ExecuteMsg::ModifyContract {
+            approvers: Some(vec!["approver_1".into(), "approver_3".into()]),
+            executors: Some(vec!["exec1".into(), "exec3".into()]),
+            ask_fee_rate: Some("0.123".into()),
+            ask_fee_account: Some("fee_acct_1".into()),
+            bid_fee_rate: Some("0.234".into()),
+            bid_fee_account: Some("fee_acct_2".into()),
+            ask_required_attributes: Some(vec!["ask_tag_1".into()]),
+            bid_required_attributes: Some(vec!["bid_tag_1".into(), "bid_tag_3".into()]),
+        };
+        let exec_info = mock_info("invalid_exec", &[]);
+        let modify_contract_response =
+            execute(deps.as_mut(), mock_env(), exec_info, modify_contract_msg);
+        match modify_contract_response {
+            Ok(_) => panic!("unexpected because invalid version"),
+            Err(error) => match error {
+                ContractError::Unauthorized => {}
+                _ => panic!("unexpected error: {:?}", error),
+            },
+        }
+
+        let contract_info = get_contract_info(&deps.storage);
+        match contract_info {
+            Err(error) => panic!("unexpected error: {:?}", error),
+            Ok(contract_info) => {
+                assert_eq!(contract_info.ask_fee_info, None);
+                assert_eq!(
+                    contract_info.convertible_base_denoms,
+                    vec!["con_base_1".to_string(), "con_base_2".to_string()]
+                );
+                assert_eq!(
+                    contract_info.executors,
+                    Vec::from([Addr::unchecked("exec_1"), Addr::unchecked("exec_2")])
+                );
+                assert_eq!(
+                    contract_info.approvers,
+                    Vec::from([Addr::unchecked("exec_1"), Addr::unchecked("exec_2")])
+                );
+                assert_eq!(contract_info.ask_fee_info, None);
+                assert_eq!(contract_info.bid_fee_info, None);
+                assert_eq!(
+                    contract_info.ask_required_attributes,
+                    vec!["ask_tag_1".to_string(), "ask_tag_2".to_string()]
+                );
+                assert_eq!(
+                    contract_info.bid_required_attributes,
+                    vec!["bid_tag_1".to_string(), "bid_tag_2".to_string()]
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn execute_modify_contract_invalid_fields() {
+        let mut deps = mock_dependencies(&[]);
+
+        let version_info = set_version_info(
+            &mut deps.storage,
+            &VersionInfoV1 {
+                definition: "def".to_string(),
+                version: "0.16.2".to_string(),
+            },
+        );
+        match version_info {
+            Err(error) => panic!("unexpected error: {:?}", error),
+            Ok(_) => {}
+        }
+        setup_test_base(
+            &mut deps.storage,
+            &ContractInfoV3 {
+                name: "contract_name".into(),
+                bind_name: "contract_bind_name".into(),
+                base_denom: "base_denom".into(),
+                convertible_base_denoms: vec!["con_base_1".into(), "con_base_2".into()],
+                supported_quote_denoms: vec!["quote_1".into(), "quote_2".into()],
+                approvers: vec![Addr::unchecked("exec_1"), Addr::unchecked("exec_2")],
+                executors: vec![Addr::unchecked("exec_1"), Addr::unchecked("exec_2")],
+                ask_fee_info: Some(FeeInfo {
+                    account: Addr::unchecked("ask_fee_account"),
+                    rate: "0.01".into(),
+                }),
+                bid_fee_info: Some(FeeInfo {
+                    account: Addr::unchecked("bid_fee_account"),
+                    rate: "0.01".into(),
+                }),
+                ask_required_attributes: vec!["ask_tag_1".into(), "ask_tag_2".into()],
+                bid_required_attributes: vec!["bid_tag_1".into(), "bid_tag_2".into()],
+                price_precision: Uint128::new(2),
+                size_increment: Uint128::new(100),
+            },
+        );
+
+        let modify_contract_msg = ExecuteMsg::ModifyContract {
+            approvers: None,
+            executors: None,
+            ask_fee_rate: None,
+            ask_fee_account: None,
+            bid_fee_rate: Some("0.0s".into()),
+            bid_fee_account: Some("bid_fee_account".into()),
+            ask_required_attributes: None,
+            bid_required_attributes: None,
+        };
+        let exec_info = mock_info("exec_1", &[]);
+        let modify_contract_response =
+            execute(deps.as_mut(), mock_env(), exec_info, modify_contract_msg);
+        match modify_contract_response {
+            Ok(_) => panic!("unexpected because invalid version"),
+            Err(error) => match error {
+                ContractError::InvalidFields { fields } => {
+                    assert_eq!(fields, vec!["bid_fee_rate".to_string()])
+                }
+                _ => panic!("unexpected error: {:?}", error),
+            },
+        }
+
+        let modify_contract_msg = ExecuteMsg::ModifyContract {
+            approvers: None,
+            executors: None,
+            ask_fee_rate: None,
+            ask_fee_account: None,
+            bid_fee_rate: Some("0.01".into()),
+            bid_fee_account: None,
+            ask_required_attributes: None,
+            bid_required_attributes: None,
+        };
+        let exec_info = mock_info("exec_1", &[]);
+        let modify_contract_response =
+            execute(deps.as_mut(), mock_env(), exec_info, modify_contract_msg);
+        match modify_contract_response {
+            Ok(_) => panic!("unexpected because invalid version"),
+            Err(error) => match error {
+                ContractError::InvalidFields { fields } => {
+                    assert_eq!(fields, vec!["bid_fee_account".to_string()])
+                }
+                _ => panic!("unexpected error: {:?}", error),
+            },
+        }
+
+        let modify_contract_msg = ExecuteMsg::ModifyContract {
+            approvers: None,
+            executors: None,
+            ask_fee_rate: None,
+            ask_fee_account: None,
+            bid_fee_rate: None,
+            bid_fee_account: Some("bid_fee_account".into()),
+            ask_required_attributes: None,
+            bid_required_attributes: None,
+        };
+        let exec_info = mock_info("exec_1", &[]);
+        let modify_contract_response =
+            execute(deps.as_mut(), mock_env(), exec_info, modify_contract_msg);
+        match modify_contract_response {
+            Ok(_) => panic!("unexpected because invalid version"),
+            Err(error) => match error {
+                ContractError::InvalidFields { fields } => {
+                    assert_eq!(fields, vec!["bid_fee_rate".to_string()])
+                }
+                _ => panic!("unexpected error: {:?}", error),
+            },
+        }
+
+        let modify_contract_msg = ExecuteMsg::ModifyContract {
+            approvers: None,
+            executors: None,
+            ask_fee_rate: Some("0.01".into()),
+            ask_fee_account: None,
+            bid_fee_rate: None,
+            bid_fee_account: None,
+            ask_required_attributes: None,
+            bid_required_attributes: None,
+        };
+        let exec_info = mock_info("exec_1", &[]);
+        let modify_contract_response =
+            execute(deps.as_mut(), mock_env(), exec_info, modify_contract_msg);
+        match modify_contract_response {
+            Ok(_) => panic!("unexpected because invalid version"),
+            Err(error) => match error {
+                ContractError::InvalidFields { fields } => {
+                    assert_eq!(fields, vec!["ask_fee_account".to_string()])
+                }
+                _ => panic!("unexpected error: {:?}", error),
+            },
+        }
+
+        let modify_contract_msg = ExecuteMsg::ModifyContract {
+            approvers: None,
+            executors: None,
+            ask_fee_rate: None,
+            ask_fee_account: Some("ask_fee_account".into()),
+            bid_fee_rate: None,
+            bid_fee_account: None,
+            ask_required_attributes: None,
+            bid_required_attributes: None,
+        };
+        let exec_info = mock_info("exec_1", &[]);
+        let modify_contract_response =
+            execute(deps.as_mut(), mock_env(), exec_info, modify_contract_msg);
+        match modify_contract_response {
+            Ok(_) => panic!("unexpected because invalid version"),
+            Err(error) => match error {
+                ContractError::InvalidFields { fields } => {
+                    assert_eq!(fields, vec!["ask_fee_rate".to_string()])
+                }
+                _ => panic!("unexpected error: {:?}", error),
+            },
+        }
+
+        let modify_contract_msg = ExecuteMsg::ModifyContract {
+            approvers: None,
+            executors: Some(vec![]),
+            ask_fee_rate: None,
+            ask_fee_account: None,
+            bid_fee_rate: None,
+            bid_fee_account: None,
+            ask_required_attributes: None,
+            bid_required_attributes: None,
+        };
+        let exec_info = mock_info("exec_1", &[]);
+        let modify_contract_response =
+            execute(deps.as_mut(), mock_env(), exec_info, modify_contract_msg);
+        match modify_contract_response {
+            Ok(_) => panic!("unexpected because invalid version"),
+            Err(error) => match error {
+                ContractError::InvalidFields { fields } => {
+                    assert_eq!(fields, vec!["executors_empty".to_string()])
+                }
+                _ => panic!("unexpected error: {:?}", error),
+            },
+        }
+    }
+
+    #[test]
+    fn execute_modify_contract_invalid_version() {
+        let mut deps = mock_dependencies(&[]);
+
+        let version_info = set_version_info(
+            &mut deps.storage,
+            &VersionInfoV1 {
+                definition: "def".to_string(),
+                version: "0.16.1".to_string(),
+            },
+        );
+        match version_info {
+            Err(error) => panic!("unexpected error: {:?}", error),
+            Ok(_) => {}
+        }
+        setup_test_base(
+            &mut deps.storage,
+            &ContractInfoV3 {
+                name: "contract_name".into(),
+                bind_name: "contract_bind_name".into(),
+                base_denom: "base_denom".into(),
+                convertible_base_denoms: vec!["con_base_1".into(), "con_base_2".into()],
+                supported_quote_denoms: vec!["quote_1".into(), "quote_2".into()],
+                approvers: vec![Addr::unchecked("exec_1"), Addr::unchecked("exec_2")],
+                executors: vec![Addr::unchecked("exec_1"), Addr::unchecked("exec_2")],
+                ask_fee_info: None,
+                bid_fee_info: None,
+                ask_required_attributes: vec!["ask_tag_1".into(), "ask_tag_2".into()],
+                bid_required_attributes: vec!["bid_tag_1".into(), "bid_tag_2".into()],
+                price_precision: Uint128::new(2),
+                size_increment: Uint128::new(100),
+            },
+        );
+
+        let contract_info = get_contract_info(&deps.storage);
+        match contract_info {
+            Err(error) => panic!("unexpected error: {:?}", error),
+            Ok(contract_info) => {
+                assert_eq!(
+                    contract_info.convertible_base_denoms,
+                    vec!["con_base_1".to_string(), "con_base_2".to_string()]
+                );
+                assert_eq!(
+                    contract_info.executors,
+                    Vec::from([Addr::unchecked("exec_1"), Addr::unchecked("exec_2")])
+                );
+                assert_eq!(
+                    contract_info.approvers,
+                    Vec::from([Addr::unchecked("exec_1"), Addr::unchecked("exec_2")])
+                );
+                assert_eq!(contract_info.ask_fee_info, None);
+                assert_eq!(contract_info.bid_fee_info, None);
+                assert_eq!(
+                    contract_info.ask_required_attributes,
+                    vec!["ask_tag_1".to_string(), "ask_tag_2".to_string()]
+                );
+                assert_eq!(
+                    contract_info.bid_required_attributes,
+                    vec!["bid_tag_1".to_string(), "bid_tag_2".to_string()]
+                );
+            }
+        }
+        let modify_contract_msg = ExecuteMsg::ModifyContract {
+            approvers: Some(vec!["approver_1".into(), "approver_3".into()]),
+            executors: Some(vec!["exec1".into(), "exec3".into()]),
+            ask_fee_rate: Some("0.123".into()),
+            ask_fee_account: Some("fee_acct_1".into()),
+            bid_fee_rate: Some("0.234".into()),
+            bid_fee_account: Some("fee_acct_2".into()),
+            ask_required_attributes: Some(vec!["ask_tag_1".into()]),
+            bid_required_attributes: Some(vec!["bid_tag_1".into(), "bid_tag_3".into()]),
+        };
+        let exec_info = mock_info("exec_1", &[]);
+        let modify_contract_response =
+            execute(deps.as_mut(), mock_env(), exec_info, modify_contract_msg);
+        match modify_contract_response {
+            Ok(_) => panic!("unexpected because invalid version"),
+            Err(error) => match error {
+                ContractError::UnsupportedUpgrade {
+                    source_version,
+                    target_version,
+                } => {
+                    assert_eq!(source_version, "<0.16.2".to_string());
+                    assert_eq!(target_version, ">=0.16.2".to_string());
+                }
+                _ => panic!("unexpected error: {:?}", error),
+            },
+        }
+
+        let contract_info = get_contract_info(&deps.storage);
+        match contract_info {
+            Err(error) => panic!("unexpected error: {:?}", error),
+            Ok(contract_info) => {
+                assert_eq!(
+                    contract_info.convertible_base_denoms,
+                    vec!["con_base_1".to_string(), "con_base_2".to_string()]
+                );
+                assert_eq!(
+                    contract_info.executors,
+                    Vec::from([Addr::unchecked("exec_1"), Addr::unchecked("exec_2")])
+                );
+                assert_eq!(
+                    contract_info.approvers,
+                    Vec::from([Addr::unchecked("exec_1"), Addr::unchecked("exec_2")])
+                );
+                assert_eq!(contract_info.ask_fee_info, None);
+                assert_eq!(contract_info.bid_fee_info, None);
+                assert_eq!(
+                    contract_info.ask_required_attributes,
+                    vec!["ask_tag_1".to_string(), "ask_tag_2".to_string()]
+                );
+                assert_eq!(
+                    contract_info.bid_required_attributes,
+                    vec!["bid_tag_1".to_string(), "bid_tag_2".to_string()]
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn execute_modify_contract_invalid_attributes() {
+        let mut deps = mock_dependencies(&[]);
+
+        let version_info = set_version_info(
+            &mut deps.storage,
+            &VersionInfoV1 {
+                definition: "def".to_string(),
+                version: "0.16.2".to_string(),
+            },
+        );
+        match version_info {
+            Err(error) => panic!("unexpected error: {:?}", error),
+            Ok(_) => {}
+        }
+
+        setup_test_base(
+            &mut deps.storage,
+            &ContractInfoV3 {
+                name: "contract_name".into(),
+                bind_name: "contract_bind_name".into(),
+                base_denom: "base_denom".into(),
+                convertible_base_denoms: vec!["con_base_1".into(), "con_base_2".into()],
+                supported_quote_denoms: vec!["quote_1".into(), "quote_2".into()],
+                approvers: vec![Addr::unchecked("approver_1"), Addr::unchecked("approver_2")],
+                executors: vec![Addr::unchecked("exec_1"), Addr::unchecked("exec_2")],
+                ask_fee_info: None,
+                bid_fee_info: None,
+                ask_required_attributes: vec!["ask_tag_1".into(), "ask_tag_2".into()],
+                bid_required_attributes: vec!["bid_tag_1".into(), "bid_tag_2".into()],
+                price_precision: Uint128::new(2),
+                size_increment: Uint128::new(100),
+            },
+        );
+
+        let contract_info = get_contract_info(&deps.storage);
+        match contract_info {
+            Err(error) => panic!("unexpected error: {:?}", error),
+            Ok(contract_info) => {
+                assert_eq!(
+                    contract_info.approvers,
+                    Vec::from([Addr::unchecked("approver_1"), Addr::unchecked("approver_2")])
+                );
+                assert_eq!(
+                    contract_info.convertible_base_denoms,
+                    vec!["con_base_1".to_string(), "con_base_2".to_string()]
+                );
+                assert_eq!(contract_info.ask_fee_info, None);
+            }
+        }
+
+        // modify ask_required_attributes with no ask
+        let exec_info = mock_info("exec_1", &[]);
+        let modify_contract_msg = ExecuteMsg::ModifyContract {
+            approvers: None,
+            executors: None,
+            ask_fee_rate: None,
+            ask_fee_account: None,
+            bid_fee_rate: None,
+            bid_fee_account: None,
+            ask_required_attributes: Some(vec!["ask_tag_1".into(), "ask_tag_2".into()]),
+            bid_required_attributes: None,
+        };
+        let modify_contract_response =
+            execute(deps.as_mut(), mock_env(), exec_info, modify_contract_msg);
+        match modify_contract_response {
+            Ok(_) => {}
+            Err(error) => panic!("unexpected error: {:?}", error),
+        }
+
+        deps.querier.with_attributes(
+            "asker",
+            &[
+                ("ask_tag_1", "ask_tag_1_value", "String"),
+                ("ask_tag_2", "ask_tag_2_value", "String"),
+            ],
+        );
+        let asker_info: MessageInfo = mock_info("asker", &[coin(100, "base_denom")]);
+        let create_ask_msg = ExecuteMsg::CreateAsk {
+            base: "base_denom".into(),
+            id: "ab5f5a62-f6fc-46d1-aa84-51ccc51ec367".into(),
+            price: "2".into(),
+            quote: "quote_1".into(),
+            size: Uint128::new(100),
+        };
+        let create_ask_response = execute(
+            deps.as_mut(),
+            mock_env(),
+            asker_info.clone(),
+            create_ask_msg.clone(),
+        );
+        match create_ask_response {
+            Ok(_) => {}
+            Err(error) => panic!("unexpected error: {:?}", error),
+        }
+
+        // modify ask_required_attributes with active ask
+        let exec_info = mock_info("exec_1", &[]);
+        let modify_contract_msg = ExecuteMsg::ModifyContract {
+            approvers: None,
+            executors: None,
+            ask_fee_rate: None,
+            ask_fee_account: None,
+            bid_fee_rate: None,
+            bid_fee_account: None,
+            ask_required_attributes: Some(vec![
+                "ask_tag_1".into(),
+                "ask_tag_2".into(),
+                "ask_tag_3".into(),
+            ]),
+            bid_required_attributes: None,
+        };
+        let modify_contract_response =
+            execute(deps.as_mut(), mock_env(), exec_info, modify_contract_msg);
+        match modify_contract_response {
+            Ok(_) => panic!("expected modifyContract validation to fail"),
+            Err(error) => match error {
+                ContractError::InvalidFields { fields } => {
+                    assert_eq!(fields, vec!["ask_required_attributes".to_string()]);
+                }
+                _ => panic!("unexpected error: {:?}", error),
+            },
+        }
+
+        deps.querier.with_attributes(
+            "bidder",
+            &[
+                ("bid_tag_1", "bid_tag_1_value", "String"),
+                ("bid_tag_2", "bid_tag_2_value", "String"),
+            ],
+        );
+        let bidder_info: MessageInfo = mock_info("bidder", &[coin(200, "quote_1")]);
+        let create_bid_msg = ExecuteMsg::CreateBid {
+            id: "ab5f5a62-f6fc-46d1-aa84-61ccc51ec367".into(),
+            base: "base_denom".into(),
+            fee: None,
+            price: "2".into(),
+            quote: "quote_1".into(),
+            quote_size: Uint128::new(100),
+            size: Uint128::new(100),
+        };
+        let create_bid_response = execute(
+            deps.as_mut(),
+            mock_env(),
+            bidder_info.clone(),
+            create_bid_msg.clone(),
+        );
+        match create_bid_response {
+            Ok(_) => {}
+            Err(error) => panic!("unexpected error: {:?}", error),
+        }
+
+        // modify bid_required_attributes with active bid
+        let exec_info = mock_info("exec_1", &[]);
+        let modify_contract_msg = ExecuteMsg::ModifyContract {
+            approvers: None,
+            executors: None,
+            ask_fee_rate: None,
+            ask_fee_account: None,
+            bid_fee_rate: None,
+            bid_fee_account: None,
+            ask_required_attributes: None,
+            bid_required_attributes: Some(vec![
+                "bid_tag_1".into(),
+                "bid_tag_2".into(),
+                "bid_tag_3".into(),
+            ]),
+        };
+        let modify_contract_response =
+            execute(deps.as_mut(), mock_env(), exec_info, modify_contract_msg);
+        match modify_contract_response {
+            Ok(_) => panic!("expected modifyContract validation to fail"),
+            Err(error) => match error {
+                ContractError::InvalidFields { fields } => {
+                    assert_eq!(fields, vec!["bid_required_attributes".to_string()]);
+                }
+                _ => panic!("unexpected error: {:?}", error),
+            },
+        }
+
+        let contract_info = get_contract_info(&deps.storage);
+        match contract_info {
+            Ok(contract_info) => {
+                assert_eq!(
+                    contract_info.ask_required_attributes,
+                    vec!["ask_tag_1".to_string(), "ask_tag_2".to_string()]
+                );
+                assert_eq!(
+                    contract_info.bid_required_attributes,
+                    vec!["bid_tag_1".to_string(), "bid_tag_2".to_string()]
+                );
+            }
+            Err(error) => panic!("unexpected error: {:?}", error),
+        }
+    }
+
+    #[test]
+    fn execute_modify_contract_add_approvers() {
+        let mut deps = mock_dependencies(&[]);
+
+        let version_info = set_version_info(
+            &mut deps.storage,
+            &VersionInfoV1 {
+                definition: "def".to_string(),
+                version: "0.16.2".to_string(),
+            },
+        );
+        match version_info {
+            Err(error) => panic!("unexpected error: {:?}", error),
+            Ok(_) => {}
+        }
+
+        setup_test_base(
+            &mut deps.storage,
+            &ContractInfoV3 {
+                name: "contract_name".into(),
+                bind_name: "contract_bind_name".into(),
+                base_denom: "base_denom".into(),
+                convertible_base_denoms: vec!["con_base_1".into(), "con_base_2".into()],
+                supported_quote_denoms: vec!["quote_1".into(), "quote_2".into()],
+                approvers: vec![Addr::unchecked("approver_1"), Addr::unchecked("approver_2")],
+                executors: vec![Addr::unchecked("exec_1"), Addr::unchecked("exec_2")],
+                ask_fee_info: None,
+                bid_fee_info: None,
+                ask_required_attributes: vec!["ask_tag_1".into(), "ask_tag_2".into()],
+                bid_required_attributes: vec!["bid_tag_1".into(), "bid_tag_2".into()],
+                price_precision: Uint128::new(2),
+                size_increment: Uint128::new(100),
+            },
+        );
+
+        let contract_info = get_contract_info(&deps.storage);
+        match contract_info {
+            Err(error) => panic!("unexpected error: {:?}", error),
+            Ok(contract_info) => {
+                assert_eq!(
+                    contract_info.approvers,
+                    Vec::from([Addr::unchecked("approver_1"), Addr::unchecked("approver_2")])
+                );
+                assert_eq!(
+                    contract_info.convertible_base_denoms,
+                    vec!["con_base_1".to_string(), "con_base_2".to_string()]
+                );
+                assert_eq!(contract_info.ask_fee_info, None);
+            }
+        }
+
+        deps.querier.with_attributes(
+            "asker",
+            &[
+                ("ask_tag_1", "ask_tag_1_value", "String"),
+                ("ask_tag_2", "ask_tag_2_value", "String"),
+            ],
+        );
+        let asker_info: MessageInfo = mock_info("asker", &[coin(100, "base_denom")]);
+        let create_ask_msg = ExecuteMsg::CreateAsk {
+            base: "base_denom".into(),
+            id: "ab5f5a62-f6fc-46d1-aa84-51ccc51ec367".into(),
+            price: "2".into(),
+            quote: "quote_1".into(),
+            size: Uint128::new(100),
+        };
+        let create_ask_response = execute(
+            deps.as_mut(),
+            mock_env(),
+            asker_info.clone(),
+            create_ask_msg.clone(),
+        );
+        match create_ask_response {
+            Ok(_) => {}
+            Err(error) => panic!("unexpected error: {:?}", error),
+        }
+
+        // empty executors not allowed, else anyone can execute
+        let exec_info = mock_info("exec_1", &[]);
+        let modify_contract_msg = ExecuteMsg::ModifyContract {
+            approvers: Some(vec!["approver_1".into(), "approver_3".into()]),
+            executors: None,
+            ask_fee_rate: None,
+            ask_fee_account: None,
+            bid_fee_rate: None,
+            bid_fee_account: None,
+            ask_required_attributes: None,
+            bid_required_attributes: None,
+        };
+        let modify_contract_response =
+            execute(deps.as_mut(), mock_env(), exec_info, modify_contract_msg);
+        match modify_contract_response {
+            Ok(_) => panic!("expected modifyContract validation to fail"),
+            Err(error) => match error {
+                ContractError::InvalidFields { fields } => {
+                    assert_eq!(fields, vec!["approvers".to_string()]);
+                }
+                _ => panic!("unexpected error: {:?}", error),
+            },
+        }
+
+        // empty executors not allowed, else anyone can execute
+        let exec_info = mock_info("exec_1", &[]);
+        let modify_contract_msg = ExecuteMsg::ModifyContract {
+            approvers: Some(vec![
+                "approver_1".into(),
+                "approver_2".into(),
+                "approver_3".into(),
+            ]),
+            executors: None,
+            ask_fee_rate: None,
+            ask_fee_account: None,
+            bid_fee_rate: None,
+            bid_fee_account: None,
+            ask_required_attributes: None,
+            bid_required_attributes: None,
+        };
+        let modify_contract_response =
+            execute(deps.as_mut(), mock_env(), exec_info, modify_contract_msg);
+        match modify_contract_response {
+            Ok(_) => {}
+            Err(error) => panic!("unexpected error: {:?}", error),
+        }
+
+        let contract_info = get_contract_info(&deps.storage);
+        match contract_info {
+            Err(error) => panic!("unexpected error: {:?}", error),
+            Ok(contract_info) => {
+                assert_eq!(
+                    contract_info.approvers,
+                    Vec::from([
+                        Addr::unchecked("approver_1"),
+                        Addr::unchecked("approver_2"),
+                        Addr::unchecked("approver_3")
+                    ])
+                );
+                assert_eq!(
+                    contract_info.convertible_base_denoms,
+                    vec!["con_base_1".to_string(), "con_base_2".to_string()]
+                );
+                assert_eq!(contract_info.ask_fee_info, None);
+            }
+        }
+    }
+
+    #[test]
+    fn execute_modify_contract_invalid_input_executors() {
+        let mut deps = mock_dependencies(&[]);
+
+        let version_info = set_version_info(
+            &mut deps.storage,
+            &VersionInfoV1 {
+                definition: "def".to_string(),
+                version: "0.16.2".to_string(),
+            },
+        );
+
+        match version_info {
+            Err(error) => panic!("unexpected error: {:?}", error),
+            Ok(_) => {}
+        }
+
+        setup_test_base(
+            &mut deps.storage,
+            &ContractInfoV3 {
+                name: "contract_name".into(),
+                bind_name: "contract_bind_name".into(),
+                base_denom: "base_denom".into(),
+                convertible_base_denoms: vec!["con_base_1".into(), "con_base_2".into()],
+                supported_quote_denoms: vec!["quote_1".into(), "quote_2".into()],
+                approvers: vec![Addr::unchecked("exec_1"), Addr::unchecked("exec_2")],
+                executors: vec![Addr::unchecked("exec_1"), Addr::unchecked("exec_2")],
+                ask_fee_info: None,
+                bid_fee_info: None,
+                ask_required_attributes: vec!["ask_tag_1".into(), "ask_tag_2".into()],
+                bid_required_attributes: vec!["bid_tag_1".into(), "bid_tag_2".into()],
+                price_precision: Uint128::new(2),
+                size_increment: Uint128::new(100),
+            },
+        );
+
+        // store valid ask order
+        store_test_ask(
+            &mut deps.storage,
+            &AskOrderV1 {
+                base: "base_1".into(),
+                class: AskOrderClass::Basic,
+                id: "ab5f5a62-f6fc-46d1-aa84-51ccc51ec367".into(),
+                owner: Addr::unchecked("asker"),
+                price: "2".into(),
+                quote: "quote_1".into(),
+                size: Uint128::new(100),
+            },
+        );
+
+        let contract_info = get_contract_info(&deps.storage);
+
+        match contract_info {
+            Err(error) => panic!("unexpected error: {:?}", error),
+            Ok(contract_info) => {
+                assert_eq!(
+                    contract_info.executors,
+                    Vec::from([Addr::unchecked("exec_1"), Addr::unchecked("exec_2")])
+                );
+                assert_eq!(
+                    contract_info.convertible_base_denoms,
+                    vec!["con_base_1".to_string(), "con_base_2".to_string()]
+                );
+                assert_eq!(contract_info.ask_fee_info, None);
+            }
+        }
+
+        // empty executors not allowed, else anyone can execute
+        let exec_info = mock_info("exec_1", &[]);
+        let modify_contract_msg = ExecuteMsg::ModifyContract {
+            approvers: Some(vec!["approver_1".into(), "approver_3".into()]),
+            executors: Some(vec![]),
+            ask_fee_rate: Some("0.123".into()),
+            ask_fee_account: Some("fee_acct_1".into()),
+            bid_fee_rate: None,
+            bid_fee_account: None,
+            ask_required_attributes: Some(vec!["ask_tag_3".into(), "ask_tag_4".into()]),
+            bid_required_attributes: Some(vec!["bid_tag_1".into(), "bid_tag_2".into()]),
+        };
+        let modify_contract_response =
+            execute(deps.as_mut(), mock_env(), exec_info, modify_contract_msg);
+        match modify_contract_response {
+            Ok(_) => panic!("expected modifyContract validation to fail"),
+            Err(error) => match error {
+                ContractError::InvalidFields { fields } => {
+                    assert_eq!(fields, vec!["executors_empty".to_string()]);
+                }
+                _ => panic!("unexpected error: {:?}", error),
+            },
+        }
+
+        // empty approvers not allowed, else anyone cn approve
+        let exec_info = mock_info("exec_1", &[]);
+        let modify_contract_msg = ExecuteMsg::ModifyContract {
+            approvers: Some(vec![]),
+            executors: None,
+            ask_fee_rate: Some("0.123".into()),
+            ask_fee_account: Some("fee_acct_1".into()),
+            bid_fee_rate: None,
+            bid_fee_account: None,
+            ask_required_attributes: Some(vec!["ask_tag_3".into(), "ask_tag_4".into()]),
+            bid_required_attributes: Some(vec!["bid_tag_1".into(), "bid_tag_2".into()]),
+        };
+        let modify_contract_response =
+            execute(deps.as_mut(), mock_env(), exec_info, modify_contract_msg);
+        match modify_contract_response {
+            Ok(_) => panic!("expected modifyContract validation to fail"),
+            Err(error) => match error {
+                ContractError::InvalidFields { fields } => {
+                    assert_eq!(fields, vec!["approvers_empty".to_string()]);
+                }
+                _ => panic!("unexpected error: {:?}", error),
+            },
+        }
+
+        let exec_info = mock_info("exec_1", &[]);
+        let modify_contract_msg = ExecuteMsg::ModifyContract {
+            approvers: None,
+            executors: None,
+            ask_fee_rate: Some("0.123".into()),
+            ask_fee_account: Some("fee_acct_1".into()),
+            bid_fee_rate: None,
+            bid_fee_account: None,
+            ask_required_attributes: None,
+            bid_required_attributes: Some(vec!["bid_tag_1".into(), "bid_tag_2".into()]),
+        };
+        let modify_contract_response =
+            execute(deps.as_mut(), mock_env(), exec_info, modify_contract_msg);
+        match modify_contract_response {
+            Ok(_) => {}
+            Err(error) => panic!("unexpected error: {:?}", error),
+        }
+    }
+
+    #[test]
+    fn execute_modify_contract_invalid_attributes_conflict() {
+        let mut deps = mock_dependencies(&[]);
+
+        let version_info = set_version_info(
+            &mut deps.storage,
+            &VersionInfoV1 {
+                definition: "def".to_string(),
+                version: "0.16.2".to_string(),
+            },
+        );
+
+        match version_info {
+            Err(error) => panic!("unexpected error: {:?}", error),
+            Ok(_) => {}
+        }
+
+        setup_test_base(
+            &mut deps.storage,
+            &ContractInfoV3 {
+                name: "contract_name".into(),
+                bind_name: "contract_bind_name".into(),
+                base_denom: "base_denom".into(),
+                convertible_base_denoms: vec!["con_base_1".into(), "con_base_2".into()],
+                supported_quote_denoms: vec!["quote_1".into(), "quote_2".into()],
+                approvers: vec![Addr::unchecked("exec_1"), Addr::unchecked("exec_2")],
+                executors: vec![Addr::unchecked("exec_1"), Addr::unchecked("exec_2")],
+                ask_fee_info: None,
+                bid_fee_info: None,
+                ask_required_attributes: vec!["ask_tag_1".into(), "ask_tag_2".into()],
+                bid_required_attributes: vec!["bid_tag_1".into(), "bid_tag_2".into()],
+                price_precision: Uint128::new(2),
+                size_increment: Uint128::new(100),
+            },
+        );
+
+        deps.querier.with_attributes(
+            "asker",
+            &[
+                ("ask_tag_1", "ask_tag_1_value", "String"),
+                ("ask_tag_2", "ask_tag_2_value", "String"),
+            ],
+        );
+
+        let asker_info: MessageInfo = mock_info("asker", &[coin(100, "base_denom")]);
+        let create_ask_msg = ExecuteMsg::CreateAsk {
+            base: "base_denom".into(),
+            id: "ab5f5a62-f6fc-46d1-aa84-51ccc51ec367".into(),
+            price: "2".into(),
+            quote: "quote_1".into(),
+            size: Uint128::new(100),
+        };
+        let create_ask_response = execute(
+            deps.as_mut(),
+            mock_env(),
+            asker_info.clone(),
+            create_ask_msg.clone(),
+        );
+        match create_ask_response {
+            Ok(_) => {}
+            Err(error) => panic!("unexpected error: {:?}", error),
+        }
+
+        let contract_info = get_contract_info(&deps.storage);
+        match contract_info {
+            Err(error) => panic!("unexpected error: {:?}", error),
+            Ok(contract_info) => {
+                assert_eq!(
+                    contract_info.executors,
+                    Vec::from([Addr::unchecked("exec_1"), Addr::unchecked("exec_2")])
+                );
+                assert_eq!(
+                    contract_info.convertible_base_denoms,
+                    vec!["con_base_1".to_string(), "con_base_2".to_string()]
+                );
+                assert_eq!(contract_info.ask_fee_info, None);
+            }
+        }
+
+        // ask_required_attributes conflict with active asks
+        let exec_info = mock_info("exec_1", &[]);
+        let modify_contract_msg = ExecuteMsg::ModifyContract {
+            approvers: Some(vec!["approver_1".into(), "approver_3".into()]),
+            executors: Some(vec!["exec_1".into(), "exec_3".into()]),
+            ask_fee_rate: Some("0.123".into()),
+            ask_fee_account: Some("fee_acct_1".into()),
+            bid_fee_rate: None,
+            bid_fee_account: None,
+            ask_required_attributes: Some(vec!["ask_tag_1".into()]),
+            bid_required_attributes: Some(vec!["bid_tag_1".into(), "bid_tag_2".into()]),
+        };
+        let modify_contract_response =
+            execute(deps.as_mut(), mock_env(), exec_info, modify_contract_msg);
+        match modify_contract_response {
+            Ok(_) => panic!("expected modifyContract validation to fail"),
+            Err(error) => match error {
+                ContractError::InvalidFields { fields } => {
+                    assert_eq!(fields, vec!["ask_required_attributes".to_string()]);
+                }
+                _ => panic!("unexpected error: {:?}", error),
+            },
+        }
+
+        let exec_info = mock_info("exec_1", &[]);
+        let modify_contract_msg = ExecuteMsg::ModifyContract {
+            approvers: Some(vec!["approver_1".into(), "approver_3".into()]),
+            executors: Some(vec!["exec_1".into(), "exec_3".into()]),
+            ask_fee_rate: Some("0.123".into()),
+            ask_fee_account: Some("fee_acct_1".into()),
+            bid_fee_rate: None,
+            bid_fee_account: None,
+            ask_required_attributes: Some(vec!["ask_tag_1".into(), "ask_tag_2".into()]),
+            bid_required_attributes: Some(vec!["bid_tag_1".into(), "bid_tag_2".into()]),
+        };
+        let modify_contract_response =
+            execute(deps.as_mut(), mock_env(), exec_info, modify_contract_msg);
+        match modify_contract_response {
+            Ok(_) => panic!("expected modifyContract validation to fail"),
+            Err(error) => match error {
+                ContractError::InvalidFields { fields } => {
+                    assert_eq!(fields, vec!["ask_required_attributes".to_string()]);
+                }
+                _ => panic!("unexpected error: {:?}", error),
+            },
+        }
+
+        let exec_info = mock_info("exec_1", &[]);
+        let modify_contract_msg = ExecuteMsg::ModifyContract {
+            approvers: Some(vec!["approver_1".into(), "approver_3".into()]),
+            executors: Some(vec!["exec_1".into(), "exec_3".into()]),
+            ask_fee_rate: Some("0.123".into()),
+            ask_fee_account: Some("fee_acct_1".into()),
+            bid_fee_rate: None,
+            bid_fee_account: None,
+            ask_required_attributes: Some(vec![
+                "ask_tag_1".into(),
+                "ask_tag_2".into(),
+                "ask_tag_3".into(),
+            ]),
+            bid_required_attributes: Some(vec!["bid_tag_1".into(), "bid_tag_2".into()]),
+        };
+        let modify_contract_response =
+            execute(deps.as_mut(), mock_env(), exec_info, modify_contract_msg);
+        match modify_contract_response {
+            Ok(_) => panic!("expected modifyContract validation to fail"),
+            Err(error) => match error {
+                ContractError::InvalidFields { fields } => {
+                    assert_eq!(fields, vec!["ask_required_attributes".to_string()]);
+                }
+                _ => panic!("unexpected error: {:?}", error),
+            },
+        }
+
+        let cancel_info: MessageInfo = mock_info("asker", &[]);
+        let cancel_ask_msg = ExecuteMsg::CancelAsk {
+            id: "ab5f5a62-f6fc-46d1-aa84-51ccc51ec367".into(),
+        };
+        let cancel_ask_response = execute(
+            deps.as_mut(),
+            mock_env(),
+            cancel_info.clone(),
+            cancel_ask_msg,
+        );
+        match cancel_ask_response {
+            Ok(_) => {}
+            Err(error) => panic!("unexpected error: {:?}", error),
+        }
+
+        let exec_info = mock_info("exec_1", &[]);
+        let modify_contract_msg = ExecuteMsg::ModifyContract {
+            approvers: Some(vec!["approver_1".into(), "approver_3".into()]),
+            executors: Some(vec!["exec1".into(), "exec3".into()]),
+            ask_fee_rate: Some("0.123".into()),
+            ask_fee_account: Some("fee_acct_1".into()),
+            bid_fee_rate: Some("0.234".into()),
+            bid_fee_account: Some("fee_acct_2".into()),
+            ask_required_attributes: Some(vec!["ask_tag_1".into()]),
+            bid_required_attributes: Some(vec!["bid_tag_1".into(), "bid_tag_3".into()]),
+        };
+        let modify_contract_response =
+            execute(deps.as_mut(), mock_env(), exec_info, modify_contract_msg);
+        match modify_contract_response {
+            Ok(_) => {}
+            Err(error) => panic!("unexpected error: {:?}", error),
+        }
+
+        let contract_info = get_contract_info(&deps.storage);
+        match contract_info {
+            Err(error) => panic!("unexpected error: {:?}", error),
+            Ok(contract_info) => {
+                assert_eq!(
+                    contract_info.convertible_base_denoms,
+                    vec!["con_base_1".to_string(), "con_base_2".to_string()]
+                );
+                assert_eq!(
+                    contract_info.executors,
+                    Vec::from([Addr::unchecked("exec1"), Addr::unchecked("exec3")])
+                );
+                assert_eq!(
+                    contract_info.approvers,
+                    Vec::from([Addr::unchecked("approver_1"), Addr::unchecked("approver_3")])
+                );
+                assert_eq!(
+                    contract_info.ask_fee_info,
+                    Some(FeeInfo {
+                        account: Addr::unchecked("fee_acct_1"),
+                        rate: "0.123".into()
+                    })
+                );
+                assert_eq!(
+                    contract_info.bid_fee_info,
+                    Some(FeeInfo {
+                        account: Addr::unchecked("fee_acct_2"),
+                        rate: "0.234".into()
+                    })
+                );
+                assert_eq!(
+                    contract_info.ask_required_attributes,
+                    vec!["ask_tag_1".to_string()]
+                );
+                assert_eq!(
+                    contract_info.bid_required_attributes,
+                    vec!["bid_tag_1".to_string(), "bid_tag_3".to_string()]
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn execute_modify_contract_valid_remove_attributes() {
+        let mut deps = mock_dependencies(&[]);
+
+        let version_info = set_version_info(
+            &mut deps.storage,
+            &VersionInfoV1 {
+                definition: "def".to_string(),
+                version: "0.16.2".to_string(),
+            },
+        );
+
+        match version_info {
+            Err(error) => panic!("unexpected error: {:?}", error),
+            Ok(_) => {}
+        }
+
+        setup_test_base(
+            &mut deps.storage,
+            &ContractInfoV3 {
+                name: "contract_name".into(),
+                bind_name: "contract_bind_name".into(),
+                base_denom: "base_denom".into(),
+                convertible_base_denoms: vec!["con_base_1".into(), "con_base_2".into()],
+                supported_quote_denoms: vec!["quote_1".into(), "quote_2".into()],
+                approvers: vec![Addr::unchecked("exec_1"), Addr::unchecked("exec_2")],
+                executors: vec![Addr::unchecked("exec_1"), Addr::unchecked("exec_2")],
+                ask_fee_info: None,
+                bid_fee_info: None,
+                ask_required_attributes: vec!["ask_tag_1".into(), "ask_tag_2".into()],
+                bid_required_attributes: vec!["bid_tag_1".into(), "bid_tag_2".into()],
+                price_precision: Uint128::new(2),
+                size_increment: Uint128::new(100),
+            },
+        );
+
+        let contract_info = get_contract_info(&deps.storage);
+        match contract_info {
+            Err(error) => panic!("unexpected error: {:?}", error),
+            Ok(contract_info) => {
+                assert_eq!(
+                    contract_info.executors,
+                    Vec::from([Addr::unchecked("exec_1"), Addr::unchecked("exec_2")])
+                );
+                assert_eq!(
+                    contract_info.convertible_base_denoms,
+                    vec!["con_base_1".to_string(), "con_base_2".to_string()]
+                );
+                assert_eq!(contract_info.ask_fee_info, None);
+            }
+        }
+
+        let exec_info = mock_info("exec_1", &[]);
+        let modify_contract_msg = ExecuteMsg::ModifyContract {
+            approvers: Some(vec!["approver_1".into(), "approver_3".into()]),
+            executors: Some(vec!["exec_1".into(), "exec_3".into()]),
+            ask_fee_rate: Some("0.123".into()),
+            ask_fee_account: Some("fee_acct_1".into()),
+            bid_fee_rate: Some("0.234".into()),
+            bid_fee_account: Some("fee_acct_2".into()),
+            ask_required_attributes: None,
+            bid_required_attributes: Some(vec![]),
+        };
+        let modify_contract_response =
+            execute(deps.as_mut(), mock_env(), exec_info, modify_contract_msg);
+        match modify_contract_response {
+            Err(error) => panic!("unexpected error: {:?}", error),
+            Ok(_) => {}
+        }
+
+        let contract_info = get_contract_info(&deps.storage);
+        match contract_info {
+            Err(error) => panic!("unexpected error: {:?}", error),
+            Ok(contract_info) => {
+                assert_eq!(
+                    contract_info.ask_required_attributes,
+                    vec!["ask_tag_1".to_string(), "ask_tag_2".to_string()]
+                );
+                let empty_vector: Vec<String> = vec![];
+                assert_eq!(contract_info.bid_required_attributes, empty_vector);
+                assert_eq!(
+                    contract_info.convertible_base_denoms,
+                    vec!["con_base_1".to_string(), "con_base_2".to_string()]
+                );
+                assert_eq!(
+                    contract_info.ask_fee_info,
+                    Some(FeeInfo {
+                        account: Addr::unchecked("fee_acct_1"),
+                        rate: "0.123".to_string(),
+                    })
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn execute_modify_contract_invalid_conflicting_bid_attributes() {
+        let mut deps = mock_dependencies(&[]);
+
+        let version_info = set_version_info(
+            &mut deps.storage,
+            &VersionInfoV1 {
+                definition: "def".to_string(),
+                version: "0.16.2".to_string(),
+            },
+        );
+
+        match version_info {
+            Err(error) => panic!("unexpected error: {:?}", error),
+            Ok(_) => {}
+        }
+
+        setup_test_base(
+            &mut deps.storage,
+            &ContractInfoV3 {
+                name: "contract_name".into(),
+                bind_name: "contract_bind_name".into(),
+                base_denom: "base_denom".into(),
+                convertible_base_denoms: vec!["con_base_1".into(), "con_base_2".into()],
+                supported_quote_denoms: vec!["quote_1".into(), "quote_2".into()],
+                approvers: vec![Addr::unchecked("exec_1"), Addr::unchecked("exec_2")],
+                executors: vec![Addr::unchecked("exec_1"), Addr::unchecked("exec_2")],
+                ask_fee_info: None,
+                bid_fee_info: None,
+                ask_required_attributes: vec![],
+                bid_required_attributes: vec!["bid_tag_1".into(), "bid_tag_2".into()],
+                price_precision: Uint128::new(2),
+                size_increment: Uint128::new(100),
+            },
+        );
+
+        let contract_info = get_contract_info(&deps.storage);
+        match contract_info {
+            Err(error) => panic!("unexpected error: {:?}", error),
+            Ok(contract_info) => {
+                assert_eq!(
+                    contract_info.executors,
+                    Vec::from([Addr::unchecked("exec_1"), Addr::unchecked("exec_2")])
+                );
+                assert_eq!(
+                    contract_info.convertible_base_denoms,
+                    vec!["con_base_1".to_string(), "con_base_2".to_string()]
+                );
+                assert_eq!(contract_info.ask_fee_info, None);
+            }
+        }
+
+        deps.querier.with_attributes(
+            "asker",
+            &[
+                ("ask_tag_1", "ask_tag_1_value", "String"),
+                ("ask_tag_2", "ask_tag_2_value", "String"),
+            ],
+        );
+        let asker_info: MessageInfo = mock_info("asker", &[coin(100, "base_denom")]);
+        let create_ask_msg = ExecuteMsg::CreateAsk {
+            base: "base_denom".into(),
+            id: "ab5f5a62-f6fc-46d1-aa84-51ccc51ec367".into(),
+            price: "2".into(),
+            quote: "quote_1".into(),
+            size: Uint128::new(100),
+        };
+        let create_ask_response = execute(
+            deps.as_mut(),
+            mock_env(),
+            asker_info.clone(),
+            create_ask_msg.clone(),
+        );
+        match create_ask_response {
+            Ok(_) => {}
+            Err(error) => panic!("unexpected error: {:?}", error),
+        }
+
+        let create_ask_msg = ExecuteMsg::CreateAsk {
+            base: "base_denom".into(),
+            id: "ab5f5a62-f6fc-46d1-aa84-51ccc51ec368".into(),
+            price: "3".into(),
+            quote: "quote_2".into(),
+            size: Uint128::new(100),
+        };
+        let create_ask_response = execute(
+            deps.as_mut(),
+            mock_env(),
+            asker_info.clone(),
+            create_ask_msg.clone(),
+        );
+        match create_ask_response {
+            Ok(_) => {}
+            Err(error) => panic!("unexpected error: {:?}", error),
+        }
+
+        deps.querier.with_attributes(
+            "bidder",
+            &[
+                ("bid_tag_1", "bid_tag_1_value", "String"),
+                ("bid_tag_2", "bid_tag_2_value", "String"),
+            ],
+        );
+        let bidder_info = mock_info("bidder", &[coin(200, "quote_1")]);
+        let create_bid_msg = ExecuteMsg::CreateBid {
+            id: "ab5f5a62-f6fc-46d1-aa84-51ccc51ec468".into(),
+            base: "base_denom".to_string(),
+            fee: None,
+            price: "2".into(),
+            quote: "quote_1".to_string(),
+            quote_size: Uint128::new(100),
+            size: Uint128::new(100),
+        };
+        let create_bid_response = execute(
+            deps.as_mut(),
+            mock_env(),
+            bidder_info.clone(),
+            create_bid_msg.clone(),
+        );
+        match create_bid_response {
+            Ok(_) => {}
+            Err(error) => panic!("unexpected error: {:?}", error),
+        }
+
+        let exec_info = mock_info("exec_1", &[]);
+        let modify_contract_msg = ExecuteMsg::ModifyContract {
+            approvers: Some(vec!["approver_1".into(), "approver_3".into()]),
+            executors: Some(vec!["exec_1".into(), "exec_3".into()]),
+            ask_fee_rate: Some("0.123".into()),
+            ask_fee_account: Some("fee_acct_1".into()),
+            bid_fee_rate: None,
+            bid_fee_account: None,
+            ask_required_attributes: None,
+            bid_required_attributes: Some(vec!["bid_tag_3".into(), "bid_tag_4".into()]),
+        };
+        let modify_contract_response =
+            execute(deps.as_mut(), mock_env(), exec_info, modify_contract_msg);
+        match modify_contract_response {
+            Ok(_) => panic!("expected modifyContract validation to fail"),
+            Err(error) => match error {
+                ContractError::InvalidFields { fields } => {
+                    assert_eq!(fields, vec!["bid_required_attributes".to_string()]);
+                }
+                _ => panic!("unexpected error: {:?}", error),
+            },
+        }
+    }
+
+    #[test]
+    fn execute_modify_contract_invalid_conflicting_bid_fee() {
+        let mut deps = mock_dependencies(&[]);
+
+        let version_info = set_version_info(
+            &mut deps.storage,
+            &VersionInfoV1 {
+                definition: "def".to_string(),
+                version: "0.16.2".to_string(),
+            },
+        );
+
+        match version_info {
+            Err(error) => panic!("unexpected error: {:?}", error),
+            Ok(_) => {}
+        }
+
+        setup_test_base(
+            &mut deps.storage,
+            &ContractInfoV3 {
+                name: "contract_name".into(),
+                bind_name: "contract_bind_name".into(),
+                base_denom: "base_denom".into(),
+                convertible_base_denoms: vec!["con_base_1".into(), "con_base_2".into()],
+                supported_quote_denoms: vec!["quote_1".into(), "quote_2".into()],
+                approvers: vec![Addr::unchecked("exec_1"), Addr::unchecked("exec_2")],
+                executors: vec![Addr::unchecked("exec_1"), Addr::unchecked("exec_2")],
+                ask_fee_info: None,
+                bid_fee_info: None,
+                ask_required_attributes: vec![],
+                bid_required_attributes: vec!["bid_tag_1".into(), "bid_tag_2".into()],
+                price_precision: Uint128::new(2),
+                size_increment: Uint128::new(100),
+            },
+        );
+
+        let contract_info = get_contract_info(&deps.storage);
+        match contract_info {
+            Err(error) => panic!("unexpected error: {:?}", error),
+            Ok(contract_info) => {
+                assert_eq!(
+                    contract_info.executors,
+                    Vec::from([Addr::unchecked("exec_1"), Addr::unchecked("exec_2")])
+                );
+                assert_eq!(
+                    contract_info.convertible_base_denoms,
+                    vec!["con_base_1".to_string(), "con_base_2".to_string()]
+                );
+                assert_eq!(contract_info.ask_fee_info, None);
+            }
+        }
+
+        deps.querier.with_attributes(
+            "bidder",
+            &[
+                ("bid_tag_1", "bid_tag_1_value", "String"),
+                ("bid_tag_2", "bid_tag_2_value", "String"),
+                ("bid_tag_3", "bid_tag_3_value", "String"),
+                ("bid_tag_4", "bid_tag_4_value", "String"),
+            ],
+        );
+        let bidder_info = mock_info("bidder", &[coin(200, "quote_1")]);
+        let create_bid_msg = ExecuteMsg::CreateBid {
+            id: "ab5f5a62-f6fc-46d1-aa84-51ccc51ec468".into(),
+            base: "base_denom".to_string(),
+            fee: None,
+            price: "2".into(),
+            quote: "quote_1".to_string(),
+            quote_size: Uint128::new(100),
+            size: Uint128::new(100),
+        };
+        let create_bid_response = execute(
+            deps.as_mut(),
+            mock_env(),
+            bidder_info.clone(),
+            create_bid_msg.clone(),
+        );
+        match create_bid_response {
+            Ok(_) => {}
+            Err(error) => panic!("unexpected error: {:?}", error),
+        }
+
+        let exec_info = mock_info("exec_1", &[]);
+        let modify_contract_msg = ExecuteMsg::ModifyContract {
+            approvers: Some(vec!["approver_1".into(), "approver_3".into()]),
+            executors: Some(vec!["exec_1".into(), "exec_3".into()]),
+            ask_fee_rate: Some("0.123".into()),
+            ask_fee_account: Some("fee_acct_1".into()),
+            bid_fee_rate: Some("0.234".into()),
+            bid_fee_account: Some("fee_acct_1".into()),
+            ask_required_attributes: None,
+            bid_required_attributes: Some(vec![
+                "bid_tag_1".into(),
+                "bid_tag_2".into(),
+                "bid_tag_3".into(),
+            ]),
+        };
+        let modify_contract_response =
+            execute(deps.as_mut(), mock_env(), exec_info, modify_contract_msg);
+        match modify_contract_response {
+            Ok(_) => panic!("expected modifyContract validation to fail"),
+            Err(error) => match error {
+                ContractError::InvalidFields { fields } => {
+                    assert_eq!(fields, vec!["bid_required_attributes".to_string()]);
+                }
+                _ => panic!("unexpected error: {:?}", error),
+            },
+        }
+
+        let exec_info = mock_info("exec_1", &[]);
+        let modify_contract_msg = ExecuteMsg::ModifyContract {
+            approvers: Some(vec!["approver_1".into(), "approver_3".into()]),
+            executors: Some(vec!["exec_1".into(), "exec_3".into()]),
+            ask_fee_rate: Some("0.123".into()),
+            ask_fee_account: Some("fee_acct_1".into()),
+            bid_fee_rate: Some("0.234".into()),
+            bid_fee_account: Some("fee_acct_1".into()),
+            ask_required_attributes: None,
+            bid_required_attributes: None,
+        };
+        let modify_contract_response =
+            execute(deps.as_mut(), mock_env(), exec_info, modify_contract_msg);
+        match modify_contract_response {
+            Ok(_) => panic!("expected modifyContract validation to fail"),
+            Err(error) => match error {
+                ContractError::InvalidFields { fields } => {
+                    assert_eq!(fields, vec!["bid_fee".to_string()]);
+                }
+                _ => panic!("unexpected error: {:?}", error),
+            },
+        }
+
+        let cancel_info: MessageInfo = mock_info("bidder", &[]);
+        let cancel_bid_msg = ExecuteMsg::CancelBid {
+            id: "ab5f5a62-f6fc-46d1-aa84-51ccc51ec468".into(),
+        };
+        let cancel_bid_response = execute(
+            deps.as_mut(),
+            mock_env(),
+            cancel_info.clone(),
+            cancel_bid_msg,
+        );
+        match cancel_bid_response {
+            Ok(_) => {}
+            Err(error) => panic!("unexpected error: {:?}", error),
+        }
+
+        let exec_info = mock_info("exec_1", &[]);
+        let modify_contract_msg = ExecuteMsg::ModifyContract {
+            approvers: Some(vec!["approver_1".into(), "approver_3".into()]),
+            executors: Some(vec!["exec1".into(), "exec3".into()]),
+            ask_fee_rate: Some("0.123".into()),
+            ask_fee_account: Some("fee_acct_1".into()),
+            bid_fee_rate: Some("0.234".into()),
+            bid_fee_account: Some("fee_acct_2".into()),
+            ask_required_attributes: Some(vec!["ask_tag_1".into()]),
+            bid_required_attributes: Some(vec!["bid_tag_1".into(), "bid_tag_3".into()]),
+        };
+        let modify_contract_response =
+            execute(deps.as_mut(), mock_env(), exec_info, modify_contract_msg);
+        match modify_contract_response {
+            Ok(_) => {}
+            Err(error) => panic!("unexpected error: {:?}", error),
+        }
+
+        let contract_info = get_contract_info(&deps.storage);
+        match contract_info {
+            Err(error) => panic!("unexpected error: {:?}", error),
+            Ok(contract_info) => {
+                assert_eq!(
+                    contract_info.convertible_base_denoms,
+                    vec!["con_base_1".to_string(), "con_base_2".to_string()]
+                );
+                assert_eq!(
+                    contract_info.executors,
+                    Vec::from([Addr::unchecked("exec1"), Addr::unchecked("exec3")])
+                );
+                assert_eq!(
+                    contract_info.approvers,
+                    Vec::from([Addr::unchecked("approver_1"), Addr::unchecked("approver_3")])
+                );
+                assert_eq!(
+                    contract_info.ask_fee_info,
+                    Some(FeeInfo {
+                        account: Addr::unchecked("fee_acct_1"),
+                        rate: "0.123".into()
+                    })
+                );
+                assert_eq!(
+                    contract_info.bid_fee_info,
+                    Some(FeeInfo {
+                        account: Addr::unchecked("fee_acct_2"),
+                        rate: "0.234".into()
+                    })
+                );
+                assert_eq!(
+                    contract_info.ask_required_attributes,
+                    vec!["ask_tag_1".to_string()]
+                );
+                assert_eq!(
+                    contract_info.bid_required_attributes,
+                    vec!["bid_tag_1".to_string(), "bid_tag_3".to_string()]
+                );
+            }
+        }
     }
 
     #[test]

--- a/src/contract_info.rs
+++ b/src/contract_info.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::common::FeeInfo;
 use crate::error::ContractError;
-use crate::msg::{MigrateMsg, ModifyMsg};
+use crate::msg::MigrateMsg;
 use crate::version_info::get_version_info;
 use provwasm_std::ProvenanceQuery;
 use semver::{Version, VersionReq};
@@ -290,7 +290,14 @@ pub fn migrate_contract_info(
 
 pub fn modify_contract_info(
     deps: DepsMut<ProvenanceQuery>,
-    msg: &ModifyMsg,
+    approvers: Option<Vec<String>>,
+    executors: Option<Vec<String>>,
+    ask_fee_rate: Option<String>,
+    ask_fee_account: Option<String>,
+    bid_fee_rate: Option<String>,
+    bid_fee_account: Option<String>,
+    ask_required_attributes: Option<Vec<String>>,
+    bid_required_attributes: Option<Vec<String>>,
 ) -> Result<ContractInfoV3, ContractError> {
     let store = deps.storage;
     let api = deps.api;
@@ -305,7 +312,7 @@ pub fn modify_contract_info(
     }
 
     let mut contract_info = get_contract_info(store)?;
-    match &msg.approvers {
+    match &approvers {
         None => {}
         Some(approvers) => {
             let mut new_approvers: Vec<Addr> = Vec::new();
@@ -318,7 +325,7 @@ pub fn modify_contract_info(
         }
     }
 
-    match &msg.executors {
+    match &executors {
         None => {}
         Some(executors) => {
             let mut new_executors: Vec<Addr> = Vec::new();
@@ -331,7 +338,7 @@ pub fn modify_contract_info(
         }
     }
 
-    match (&msg.ask_fee_account, &msg.ask_fee_rate) {
+    match (&ask_fee_account, &ask_fee_rate) {
         (Some(account), Some(rate)) => {
             contract_info.ask_fee_info = match (account.as_str(), rate.as_str()) {
                 ("", "") => None,
@@ -350,7 +357,7 @@ pub fn modify_contract_info(
         (_, _) => (),
     };
 
-    match (&msg.bid_fee_account, &msg.bid_fee_rate) {
+    match (&bid_fee_account, &bid_fee_rate) {
         (Some(account), Some(rate)) => {
             contract_info.bid_fee_info = match (account.as_str(), rate.as_str()) {
                 ("", "") => None,
@@ -369,14 +376,14 @@ pub fn modify_contract_info(
         (_, _) => (),
     };
 
-    match &msg.ask_required_attributes {
+    match &ask_required_attributes {
         None => {}
         Some(ask_required_attributes) => {
             contract_info.ask_required_attributes = ask_required_attributes.clone();
         }
     }
 
-    match &msg.bid_required_attributes {
+    match &bid_required_attributes {
         None => {}
         Some(bid_required_attributes) => {
             contract_info.bid_required_attributes = bid_required_attributes.clone();
@@ -402,7 +409,7 @@ mod tests {
         modify_contract_info, ContractInfoV3, CONTRACT_INFO_V1, CONTRACT_INFO_V2,
     };
     use crate::error::ContractError;
-    use crate::msg::{MigrateMsg, ModifyMsg};
+    use crate::msg::MigrateMsg;
     use crate::version_info::{set_version_info, VersionInfoV1};
     use cosmwasm_std::{Addr, Uint128};
 

--- a/src/contract_info.rs
+++ b/src/contract_info.rs
@@ -7,7 +7,7 @@ use serde::{Deserialize, Serialize};
 
 use crate::common::FeeInfo;
 use crate::error::ContractError;
-use crate::msg::MigrateMsg;
+use crate::msg::{MigrateMsg, ModifyMsg};
 use crate::version_info::get_version_info;
 use provwasm_std::ProvenanceQuery;
 use semver::{Version, VersionReq};
@@ -256,7 +256,107 @@ pub fn migrate_contract_info(
                 ("", "") => None,
                 (_, _) => {
                     Decimal::from_str(rate).map_err(|_| ContractError::InvalidFields {
+                        fields: vec![String::from("bid_fee_rate")],
+                    })?;
+
+                    Some(FeeInfo {
+                        account: api.addr_validate(account)?,
+                        rate: rate.to_string(),
+                    })
+                }
+            }
+        }
+        (_, _) => (),
+    };
+
+    match &msg.ask_required_attributes {
+        None => {}
+        Some(ask_required_attributes) => {
+            contract_info.ask_required_attributes = ask_required_attributes.clone();
+        }
+    }
+
+    match &msg.bid_required_attributes {
+        None => {}
+        Some(bid_required_attributes) => {
+            contract_info.bid_required_attributes = bid_required_attributes.clone();
+        }
+    }
+
+    set_contract_info(store, &contract_info)?;
+
+    get_contract_info(store)
+}
+
+pub fn modify_contract_info(
+    deps: DepsMut<ProvenanceQuery>,
+    msg: &ModifyMsg,
+) -> Result<ContractInfoV3, ContractError> {
+    let store = deps.storage;
+    let api = deps.api;
+    let version_info = get_version_info(store)?;
+    let current_version = Version::parse(&version_info.version)?;
+
+    if VersionReq::parse("<0.16.2")?.matches(&current_version) {
+        return Err(ContractError::UnsupportedUpgrade {
+            source_version: "<0.16.2".to_string(),
+            target_version: ">=0.16.2".to_string(),
+        });
+    }
+
+    let mut contract_info = get_contract_info(store)?;
+    match &msg.approvers {
+        None => {}
+        Some(approvers) => {
+            let mut new_approvers: Vec<Addr> = Vec::new();
+            for approver_str in approvers {
+                let address = api.addr_validate(approver_str)?;
+                new_approvers.push(address);
+            }
+
+            contract_info.approvers = new_approvers;
+        }
+    }
+
+    match &msg.executors {
+        None => {}
+        Some(executors) => {
+            let mut new_executors: Vec<Addr> = Vec::new();
+            for executor_str in executors {
+                let address = api.addr_validate(executor_str)?;
+                new_executors.push(address);
+            }
+
+            contract_info.executors = new_executors;
+        }
+    }
+
+    match (&msg.ask_fee_account, &msg.ask_fee_rate) {
+        (Some(account), Some(rate)) => {
+            contract_info.ask_fee_info = match (account.as_str(), rate.as_str()) {
+                ("", "") => None,
+                (_, _) => {
+                    Decimal::from_str(rate).map_err(|_| ContractError::InvalidFields {
                         fields: vec![String::from("ask_fee_rate")],
+                    })?;
+
+                    Some(FeeInfo {
+                        account: api.addr_validate(account)?,
+                        rate: rate.to_string(),
+                    })
+                }
+            }
+        }
+        (_, _) => (),
+    };
+
+    match (&msg.bid_fee_account, &msg.bid_fee_rate) {
+        (Some(account), Some(rate)) => {
+            contract_info.bid_fee_info = match (account.as_str(), rate.as_str()) {
+                ("", "") => None,
+                (_, _) => {
+                    Decimal::from_str(rate).map_err(|_| ContractError::InvalidFields {
+                        fields: vec![String::from("bid_fee_rate")],
                     })?;
 
                     Some(FeeInfo {
@@ -298,9 +398,11 @@ mod tests {
         get_contract_info, migrate_contract_info, set_contract_info, ContractInfo, ContractInfoV1,
         ContractInfoV2, CONTRACT_INFO,
     };
-    use crate::contract_info::{ContractInfoV3, CONTRACT_INFO_V1, CONTRACT_INFO_V2};
+    use crate::contract_info::{
+        modify_contract_info, ContractInfoV3, CONTRACT_INFO_V1, CONTRACT_INFO_V2,
+    };
     use crate::error::ContractError;
-    use crate::msg::MigrateMsg;
+    use crate::msg::{MigrateMsg, ModifyMsg};
     use crate::version_info::{set_version_info, VersionInfoV1};
     use cosmwasm_std::{Addr, Uint128};
 

--- a/src/error.rs
+++ b/src/error.rs
@@ -11,6 +11,9 @@ pub enum ContractError {
     #[error("Ask order not ready: {current_status:?}")]
     AskOrderNotReady { current_status: String },
 
+    #[error("Attributes conflict with orders")]
+    ConflictingAttributes,
+
     #[error("One base required in order")]
     BaseQuantity,
 

--- a/src/msg.rs
+++ b/src/msg.rs
@@ -295,8 +295,8 @@ impl Validate for ExecuteMsg {
                 }
             }
             ExecuteMsg::ModifyContract {
-                approvers: _,
-                executors: _,
+                approvers,
+                executors,
                 ask_fee_rate,
                 ask_fee_account,
                 bid_fee_rate,
@@ -304,6 +304,22 @@ impl Validate for ExecuteMsg {
                 ask_required_attributes: _,
                 bid_required_attributes: _,
             } => {
+                match approvers {
+                    Some(vector) => {
+                        if let true = vector.as_slice().is_empty() {
+                            invalid_fields.push("approvers_empty")
+                        }
+                    }
+                    None => (),
+                }
+                match executors {
+                    Some(vector) => {
+                        if let true = vector.as_slice().is_empty() {
+                            invalid_fields.push("executors_empty")
+                        }
+                    }
+                    None => (),
+                }
                 match (ask_fee_rate, ask_fee_account) {
                     (Some(_), None) => {
                         invalid_fields.push("ask_fee_account");
@@ -373,78 +389,6 @@ impl Validate for QueryMsg {
             }
             QueryMsg::GetContractInfo {} => {}
             QueryMsg::GetVersionInfo {} => {}
-        }
-
-        match invalid_fields.len() {
-            0 => Ok(()),
-            _ => Err(ContractError::InvalidFields {
-                fields: invalid_fields.into_iter().map(|item| item.into()).collect(),
-            }),
-        }
-    }
-}
-
-pub struct ModifyMsg {
-    pub approvers: Option<Vec<String>>,
-    pub executors: Option<Vec<String>>,
-    pub ask_fee_rate: Option<String>,
-    pub ask_fee_account: Option<String>,
-    pub bid_fee_rate: Option<String>,
-    pub bid_fee_account: Option<String>,
-    pub ask_required_attributes: Option<Vec<String>>,
-    pub bid_required_attributes: Option<Vec<String>>,
-}
-
-impl Validate for ModifyMsg {
-    /// Simple validation of MigrateMsg data
-    ///
-    /// ### Example
-    ///
-    /// ```rust
-    /// use ats_smart_contract::msg::{MigrateMsg, Validate};
-    /// pub fn query(msg: MigrateMsg){
-    ///
-    ///     let result = msg.validate();
-    /// }
-    /// ```
-    fn validate(&self) -> Result<(), ContractError> {
-        let mut invalid_fields: Vec<&str> = vec![];
-
-        match &self.approvers {
-            Some(vector) => {
-                if let true = vector.as_slice().is_empty() {
-                    invalid_fields.push("approvers_empty")
-                }
-            }
-            None => (),
-        }
-        match &self.executors {
-            Some(vector) => {
-                if let true = vector.as_slice().is_empty() {
-                    invalid_fields.push("executors_empty")
-                }
-            }
-            None => (),
-        }
-        match (&self.ask_fee_rate, &self.ask_fee_account) {
-            (Some(_), None) => {
-                invalid_fields.push("ask_fee_account");
-            }
-            (None, Some(_)) => {
-                invalid_fields.push("ask_fee_rate");
-            }
-            (Some(_), Some(_)) => (),
-            (None, None) => (),
-        }
-        match (&self.bid_fee_rate, &self.bid_fee_account) {
-            (Some(_), None) => {
-                invalid_fields.push("bid_fee_account");
-            }
-            (None, Some(_)) => {
-                invalid_fields.push("bid_fee_rate");
-            }
-            (Some(_), Some(_)) => (),
-            (None, None) => (),
         }
 
         match invalid_fields.len() {

--- a/src/msg.rs
+++ b/src/msg.rs
@@ -139,6 +139,16 @@ pub enum ExecuteMsg {
         id: String,
         size: Option<Uint128>,
     },
+    ModifyContract {
+        approvers: Option<Vec<String>>,
+        executors: Option<Vec<String>>,
+        ask_fee_rate: Option<String>,
+        ask_fee_account: Option<String>,
+        bid_fee_rate: Option<String>,
+        bid_fee_account: Option<String>,
+        ask_required_attributes: Option<Vec<String>>,
+        bid_required_attributes: Option<Vec<String>>,
+    },
 }
 
 impl Validate for ExecuteMsg {
@@ -284,6 +294,37 @@ impl Validate for ExecuteMsg {
                     }
                 }
             }
+            ExecuteMsg::ModifyContract {
+                approvers: _,
+                executors: _,
+                ask_fee_rate,
+                ask_fee_account,
+                bid_fee_rate,
+                bid_fee_account,
+                ask_required_attributes: _,
+                bid_required_attributes: _,
+            } => {
+                match (ask_fee_rate, ask_fee_account) {
+                    (Some(_), None) => {
+                        invalid_fields.push("ask_fee_account");
+                    }
+                    (None, Some(_)) => {
+                        invalid_fields.push("ask_fee_rate");
+                    }
+                    (Some(_), Some(_)) => (),
+                    (None, None) => (),
+                }
+                match (bid_fee_rate, bid_fee_account) {
+                    (Some(_), None) => {
+                        invalid_fields.push("bid_fee_account");
+                    }
+                    (None, Some(_)) => {
+                        invalid_fields.push("bid_fee_rate");
+                    }
+                    (Some(_), Some(_)) => (),
+                    (None, None) => (),
+                }
+            }
         }
 
         match invalid_fields.len() {
@@ -332,6 +373,78 @@ impl Validate for QueryMsg {
             }
             QueryMsg::GetContractInfo {} => {}
             QueryMsg::GetVersionInfo {} => {}
+        }
+
+        match invalid_fields.len() {
+            0 => Ok(()),
+            _ => Err(ContractError::InvalidFields {
+                fields: invalid_fields.into_iter().map(|item| item.into()).collect(),
+            }),
+        }
+    }
+}
+
+pub struct ModifyMsg {
+    pub approvers: Option<Vec<String>>,
+    pub executors: Option<Vec<String>>,
+    pub ask_fee_rate: Option<String>,
+    pub ask_fee_account: Option<String>,
+    pub bid_fee_rate: Option<String>,
+    pub bid_fee_account: Option<String>,
+    pub ask_required_attributes: Option<Vec<String>>,
+    pub bid_required_attributes: Option<Vec<String>>,
+}
+
+impl Validate for ModifyMsg {
+    /// Simple validation of MigrateMsg data
+    ///
+    /// ### Example
+    ///
+    /// ```rust
+    /// use ats_smart_contract::msg::{MigrateMsg, Validate};
+    /// pub fn query(msg: MigrateMsg){
+    ///
+    ///     let result = msg.validate();
+    /// }
+    /// ```
+    fn validate(&self) -> Result<(), ContractError> {
+        let mut invalid_fields: Vec<&str> = vec![];
+
+        match &self.approvers {
+            Some(vector) => {
+                if let true = vector.as_slice().is_empty() {
+                    invalid_fields.push("approvers_empty")
+                }
+            }
+            None => (),
+        }
+        match &self.executors {
+            Some(vector) => {
+                if let true = vector.as_slice().is_empty() {
+                    invalid_fields.push("executors_empty")
+                }
+            }
+            None => (),
+        }
+        match (&self.ask_fee_rate, &self.ask_fee_account) {
+            (Some(_), None) => {
+                invalid_fields.push("ask_fee_account");
+            }
+            (None, Some(_)) => {
+                invalid_fields.push("ask_fee_rate");
+            }
+            (Some(_), Some(_)) => (),
+            (None, None) => (),
+        }
+        match (&self.bid_fee_rate, &self.bid_fee_account) {
+            (Some(_), None) => {
+                invalid_fields.push("bid_fee_account");
+            }
+            (None, Some(_)) => {
+                invalid_fields.push("bid_fee_rate");
+            }
+            (Some(_), Some(_)) => (),
+            (None, None) => (),
         }
 
         match invalid_fields.len() {


### PR DESCRIPTION
issue 80: Allow a message to be sent to update contract config. 

this version has multiple commits squashed.

draft version comments are here: https://github.com/wng-figure/ats-smart-contract/pull/1
